### PR TITLE
Fix scrambling of rows in getting processed company data

### DIFF
--- a/ITR/data/base_providers.py
+++ b/ITR/data/base_providers.py
@@ -156,16 +156,17 @@ class BaseProviderProductionBenchmark(ProductionBenchmarkDataProvider):
 
         return df_bm
 
-    def get_company_projected_production(self, ghg_scope12: pd.DataFrame) -> pd.DataFrame:
+    def get_company_projected_production(self, company_sector_region_info: pd.DataFrame) -> pd.DataFrame:
         """
         get the projected productions for list of companies in ghg_scope12
-        :param ghg_scope12: DataFrame with at least the following columns :
-        ColumnsConfig.COMPANY_ID,ColumnsConfig.GHG_SCOPE12, ColumnsConfig.SECTOR and ColumnsConfig.REGION
+        :param company_sector_region_info: DataFrame with at least the following columns :
+        ColumnsConfig.COMPANY_ID, ColumnsConfig.GHG_SCOPE12, ColumnsConfig.SECTOR and ColumnsConfig.REGION
         :return: DataFrame of projected productions for [base_year - base_year + 50]
         """
-        benchmark_production_projections = self.get_benchmark_projections(ghg_scope12)
-        return benchmark_production_projections.add(1).cumprod(axis=1).mul(
-            ghg_scope12[self.column_config.GHG_SCOPE12].values, axis=0)
+        benchmark_production_projections = self.get_benchmark_projections(company_sector_region_info)
+        return benchmark_production_projections\
+            .add(1).cumprod(axis=1).mul(
+            company_sector_region_info[self.column_config.GHG_SCOPE12].values, axis=0)
 
     def get_benchmark_projections(self, company_sector_region_info: pd.DataFrame,
                                   scope: EScope = EScope.S1S2) -> pd.DataFrame:

--- a/ITR/portfolio_aggregation.py
+++ b/ITR/portfolio_aggregation.py
@@ -92,8 +92,8 @@ class PortfolioAggregation(ABC):
 
         # Total emissions weighted temperature score (TETS)
         elif portfolio_aggregation_method == PortfolioAggregationMethod.TETS:
-            use_S1S2 = (data[self.c.COLS.SCOPE] == EScope.S1S2) | (data[self.c.COLS.SCOPE] == EScope.S1S2S3)
-            use_S3 = (data[self.c.COLS.SCOPE] == EScope.S3) | (data[self.c.COLS.SCOPE] == EScope.S1S2S3)
+            use_S1S2 = data[self.c.COLS.SCOPE].isin([EScope.S1S2, EScope.S1S2S3])
+            use_S3 = data[self.c.COLS.SCOPE].isin([EScope.S3, EScope.S1S2S3])
             if use_S3.any():
                 self._check_column(data, self.c.COLS.GHG_SCOPE3)
             if use_S1S2.any():
@@ -120,8 +120,8 @@ class PortfolioAggregation(ABC):
             try:
                 self._check_column(data, self.c.COLS.INVESTMENT_VALUE)
                 self._check_column(data, value_column)
-                use_S1S2 = (data[self.c.COLS.SCOPE] == EScope.S1S2) | (data[self.c.COLS.SCOPE] == EScope.S1S2S3)
-                use_S3 = (data[self.c.COLS.SCOPE] == EScope.S3) | (data[self.c.COLS.SCOPE] == EScope.S1S2S3)
+                use_S1S2 = data[self.c.COLS.SCOPE].isin([EScope.S1S2, EScope.S1S2S3])
+                use_S3 = data[self.c.COLS.SCOPE].isin([EScope.S3, EScope.S1S2S3])
                 if use_S1S2.any():
                     self._check_column(data, self.c.COLS.GHG_SCOPE12)
                 if use_S3.any():


### PR DESCRIPTION
This PR is a cherry-picked version of the 'Create credible temp score using RMI data' PR, concentrating on fixing the scrambling of the rows in 'data_warehouse.py' that had the potential of mixing up intermediate computation results of different companies. 

It does not update data input, rename functions and variables rigorously, or fix the selection of GHG_SCOPE12 emissions to compute projected productions in 'base_provider.py'.