### PR TITLE
Address ITR #104

### DIFF
--- a/test/test_portfolio_aggregation.py
+++ b/test/test_portfolio_aggregation.py
@@ -21,8 +21,8 @@ class TestPortfolioAggregation(unittest.TestCase):
         self.data.loc[:, ColumnsConfig.COMPANY_MARKET_CAP] = [1.0, 2.0, 3.0]
         self.data.loc[:, ColumnsConfig.INVESTMENT_VALUE] = [1.0, 2.0, 3.0]
         self.data.loc[:, ColumnsConfig.SCOPE] = [EScope.S1S2, EScope.S1S2, EScope.S1S2S3]
-        self.data.loc[:, ColumnsConfig.GHG_SCOPE12] = pd.Series([1.0, 2.0, 3.0], dtype='pint[MWh]')
-        self.data.loc[:, ColumnsConfig.GHG_SCOPE3] = pd.Series([1.0, 2.0, 3.0], dtype='pint[MWh]')
+        self.data.loc[:, ColumnsConfig.GHG_SCOPE12] = pd.Series([1.0, 2.0, 3.0], dtype='pint[t CO2]')
+        self.data.loc[:, ColumnsConfig.GHG_SCOPE3] = pd.Series([1.0, 2.0, 3.0], dtype='pint[t CO2]')
         self.data.loc[:, ColumnsConfig.COMPANY_ENTERPRISE_VALUE] = [1.0, 2.0, 3.0]
         self.data.loc[:, ColumnsConfig.CASH_EQUIVALENTS] = [1.0, 2.0, 3.0]
         self.data.loc[:, ColumnsConfig.COMPANY_EV_PLUS_CASH] = [1.0, 2.0, 3.0]


### PR DESCRIPTION
Signed-off-by: MichaelTiemannOSC <mtiemann@os-climate.org>

https://github.com/os-climate/ITR/issues/104

Per other changes we have implemented, GHG_SCOPE12 and GHG_SCOPE3 are emissions (t CO2) rather than production (such as MWh or Fe_ton).  When dealing with single tons, rather than MWh, pint should not introduce an extra factor of 1000000 erroneously coming from MWh.

But to complete this pull request, we must find other locations in which GHG_SCOPE12 is being erroneously treated as a production, rather than an emissions factor.  Quoting interfaces.py:

```
    # These three instance variables match against financial data below, but are incomplete as historic_data and target_data
    base_year_production: Optional[Quantity[ProductionMetric]]
    ghg_s1s2: Optional[Quantity[EmissionsMetric]]
    ghg_s3: Optional[Quantity[EmissionsMetric]]
```