### PR TITLE
Create benchmark dataframes inside the scope of inhibited warnings

### DIFF
--- a/ITR/data/base_providers.py
+++ b/ITR/data/base_providers.py
@@ -290,10 +290,12 @@ class BaseCompanyDataProvider(CompanyDataProvider):
                         self.column_config.SECTOR: [c.sector],
                         self.column_config.REGION: [c.region],
                     }, index=[0])
-                bm_production_data = (production_bm.get_company_projected_production(company_sector_region_info)
-                                      # We transpose the data so that we get a pd.Series that will accept the pint units as a whole (not element-by-element)
-                                      .iloc[0].T
-                                      .astype(f'pint[{str(base_year_production.units)}]'))
+                    bm_production_data = (
+                            production_bm.get_company_projected_production(company_sector_region_info)
+                            # We transpose the data so that we get a pd.Series that will accept the pint units as a whole (not element-by-element)
+                            .iloc[0].T
+                            .astype(f'pint[{str(base_year_production.units)}]')
+                            )
                 c.projected_targets = EITargetProjector().project_ei_targets(c, bm_production_data)
     
     # ??? Why prefer TRAJECTORY over TARGET?

--- a/ITR/data/data_warehouse.py
+++ b/ITR/data/data_warehouse.py
@@ -50,8 +50,11 @@ class DataWarehouse(ABC):
         df_company_data = pd.DataFrame.from_records([c.dict() for c in company_data]).set_index(self.column_config.COMPANY_ID, drop=False)
 
         company_info_at_base_year = self.company_data.get_company_intensity_and_production_at_base_year(company_ids)
-        projected_production = self.benchmark_projected_production.get_company_projected_production(
-            company_info_at_base_year).sort_index()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # See https://github.com/hgrecco/pint-pandas/issues/128
+            projected_production = self.benchmark_projected_production.get_company_projected_production(
+                company_info_at_base_year).sort_index()
 
         # trajectories are projected from historic data and we are careful to fill all gaps between historic and projections
         projected_trajectories = self.company_data.get_company_projected_trajectories(company_ids)

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,6 +1,5 @@
 # While ITR is not available on PyPI: comment out line 2, else: comment out or delete line 3
-# ITR==1.0.0
--e ../.
+ITR
 dash==2.4.1
 dash_bootstrap_components==1.1.0
 jupyter==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='ITR',
-    version='1.0.1',
+    version='1.0.2',
     description='Assess the temperature alignment of current targets, commitments, and investment '
                 'and lending portfolios.',
     long_description=long_description,


### PR DESCRIPTION
Otherwise the tool is very noisy (both inside GUI and Notebooks).

Note that _all_ this change does is quiet unnecessary warning messages, which will make for better demos.

Signed-off-by: MichaelTiemann <72577720+MichaelTiemannOSC@users.noreply.github.com>