### PR TITLE
Update gh-action-pip-audit to latest version

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Install
       run: python -m pip install .
     - name: Run pip-audit
-      uses: trailofbits/gh-action-pip-audit@v1.0.0
+      uses: pypa/gh-action-pip-audit@v1.0.3

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
                       'pint-pandas>=0.2',
                       'pip>=22.0.3',
                       'pydantic>=1.8.2',
-                      'setuptools>=60.9.3',
+                      'setuptools>=65.5.1',
                       'wheel>=0.36.2',
                       'xlrd>=2.0.1',
                       ],


### PR DESCRIPTION
This also includes an update to the organization name. "trailofbits" redirects to pypa now, and while this is functional for now, having the current name decreases the likelihood of problems down the line.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>