### PR TITLE
Fix all-NA rows of data in V1 template

### DIFF
--- a/ITR/data/template.py
+++ b/ITR/data/template.py
@@ -517,7 +517,7 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
                    .set_index('company_id'))
             df2.loc[df2[ColumnsConfig.SCOPE] == 'production', ColumnsConfig.VARIABLE] = VariablesConfig.PRODUCTIONS
             df2.loc[df2[ColumnsConfig.SCOPE] != 'production', ColumnsConfig.VARIABLE] = VariablesConfig.EMISSIONS
-            df3 = df2.reset_index().set_index(['company_id', 'variable', 'scope'])
+            df3 = df2.reset_index().set_index(['company_id', 'variable', 'scope']).dropna(how='all')
             df3 = pd.concat([df3.xs(VariablesConfig.PRODUCTIONS, level=1, drop_level=False)
                 .apply(
                 lambda x: x.map(lambda y: Q_(float(y) if y is not pd.NA else np.nan,

--- a/test/test_template_provider.py
+++ b/test/test_template_provider.py
@@ -153,15 +153,17 @@ class TestTemplateProvider(unittest.TestCase):
 
         # verify company scores; ALLETE, Inc. (US0185223007) and Ameren Corp. (US0236081024) have no S1 data
         if ITR.HAS_UNCERTAINTIES:
-            expected_s1 = pd.Series([2.3001523322883024, 3.2, 2.05035998, 3.2, 2.1509743549550446], dtype='pint[delta_degC]')
+            expected_s1 = pd.Series([2.3001523322883024, 2.05035998, 2.1509743549550446], dtype='pint[delta_degC]')
         else:
-            expected_s1 = pd.Series([2.3001523322883024, 3.2, 1.981747725145536, 3.2, 2.1509743549550446], dtype='pint[delta_degC]')
+            expected_s1 = pd.Series([2.3001523322883024, 1.981747725145536, 2.1509743549550446], dtype='pint[delta_degC]')
         assert_pint_series_equal(self, pd.Series(ITR.nominal_values(scores_s1.temperature_score.pint.m), dtype='pint[delta_degC]'), expected_s1, places=2)
         # verify that results exist
         if ITR.HAS_UNCERTAINTIES:
-            self.assertAlmostEqual(agg_scores_s1.long.S1.all.score, Q_(2.57712097, ureg.delta_degC), places=2)
+            # If we treat missing S1 as default 3.2C, we get 2.57712097˚C
+            self.assertAlmostEqual(agg_scores_s1.long.S1.all.score, Q_(2.1671622229062195, ureg.delta_degC), places=2)
         else:
-            self.assertAlmostEqual(agg_scores_s1.long.S1.all.score, Q_(2.56339852, ureg.delta_degC), places=2)
+            # If we treat missing S1 as default 3.2C, we get 2.56339852˚C
+            self.assertAlmostEqual(agg_scores_s1.long.S1.all.score, Q_(2.14429147, ureg.delta_degC), places=2)
         
 
     def test_get_projected_value(self):


### PR DESCRIPTION
When translating Template V1 data, it could happen that all ghg_s3 data is NA, which would create an all-NA row of emissions data.  This was properly handled in Template V2 processing, but not in Template V1 processing.  Changing this required fixing the test case `test_temp_score_from_excel_data` in test_template_provider.py (which allowed missing data to be represented by the default temperature score 3.2˚C).

Once fixed, it revealed a second problem, which was handling mixed float64 and UFloat data across target and trajectory projections.

And finally, a third problem, which was that column order for the output spreadsheet was not stable (due to using a set intersection operation, which hashes values and potentially changes their order).

Now, all fixed.  The big question is: should we fix the problem this way (dropping companies that are missing scope data from scope calculations), or should we fix another way (by inserting default temperature scores)?