### PR TITLE
assert_pint_*_equal vs. uncertainties

### DIFF
--- a/ITR/data/osc_units.py
+++ b/ITR/data/osc_units.py
@@ -797,7 +797,7 @@ def asPintDataFrame(df: pd.DataFrame, errors='ignore', inplace=False) -> pd.Data
     else:
         new_df = pd.DataFrame()
     for col in df.columns:
-        new_df[col] = asPintSeries(df[col].squeeze(), name=col, errors=errors, inplace=inplace)
+        new_df[col] = asPintSeries(df[col], name=col, errors=errors, inplace=inplace)
     new_df.index = df.index
     # When DF.COLUMNS is a MultiIndex, the naive column-by-column construction replaces MultiIndex values
     # with the anonymous tuple of the MultiIndex and DF.COLUMNS becomes just an Index of tuples.

--- a/test/test_template_provider.py
+++ b/test/test_template_provider.py
@@ -86,7 +86,7 @@ class TestTemplateProvider(unittest.TestCase):
             if c.projected_targets.S1S2 is None and temp is None:
                 continue
             if isinstance(c.projected_targets.S1S2.projections, pd.Series):
-                assert all(ITR.nominal_values(c.projected_targets.S1S2.projections.values.data)==ITR.nominal_values(temp.projections.values.data))
+                assert_pint_series_equal(self, c.projected_targets.S1S2.projections, temp.projections)
             else:
                 assert c.projected_targets.S1S2 == temp
 

--- a/test/test_template_v2.py
+++ b/test/test_template_v2.py
@@ -3,6 +3,7 @@ import os
 import unittest
 from numpy.testing import assert_array_equal
 import pandas as pd
+from pint_pandas import PintArray as PA_
 
 import ITR
 from ITR.data.osc_units import ureg, Q_, M_, asPintSeries, requantify_df_from_columns
@@ -85,35 +86,37 @@ class TestTemplateProviderV2(unittest.TestCase):
 
         selected_company_ids = [ 'US00130H1059', 'US26441C2044', 'KR7005490008' ]
 
-        expected_projections = {
-            selected_company_ids[0]: ('S1S2', [ 0.602, 0.5385, 0.4816, 0.4307, 0.3852, 0.3445, 0.3081, 0.2754,
+        expected_data = pd.DataFrame({
+            (selected_company_ids[0] ,'S1S2'): PA_([ 0.602, 0.5385, 0.4816, 0.4307, 0.3852, 0.3445, 0.3081, 0.2754,
             0.2462, 0.1972, 0.1578, 0.1258, 0.0998, 0.0786, 0.061, 0.0464, 0.0342, 0.0238,
             0.015, 0.013, 0.0111, 0.0094, 0.0078, 0.0063, 0.0049, 0.0035, 0.0023, 0.0011,
-                                   0.0 ]),
-            selected_company_ids[1]: ('S1', [ 0.2987, 0.2744, 0.2519, 0.2311, 0.2118, 0.1939, 0.1774, 0.162,
+                                                    0.0 ], dtype='t CO2e/MWh'),
+            (selected_company_ids[1], 'S1'): PA_([ 0.2987, 0.2744, 0.2519, 0.2311, 0.2118, 0.1939, 0.1774, 0.162,
             0.1477, 0.1344, 0.1221, 0.1106, 0.1, 0.0901, 0.0808, 0.0722, 0.0642, 0.0567,
             0.0497, 0.0432, 0.0371, 0.0314,  0.026,  0.021, 0.0163, 0.0118, 0.0077, 0.0037,
-                                   -0.0 ]),
-            selected_company_ids[2]: ('S1S2', [2.0046, 1.9561, 1.9088, 1.8626, 1.8176, 1.7736, 1.7307, 1.6888,
+                                                   -0.0 ], dtype='t CO2e/MWh'),
+            (selected_company_ids[2], 'S1S2'): PA_([2.0046, 1.9561, 1.9088, 1.8626, 1.8176, 1.7736, 1.7307, 1.6888,
             1.648, 1.5723, 1.5001, 1.4313, 1.3656, 1.3029, 1.243, 1.186, 1.1315, 1.0796,
             1.03, 0.8003, 0.6178, 0.4724, 0.3561, 0.2627, 0.1873, 0.126, 0.0759, 0.0345,
-                                   -0.0])
-        }
+                                               -0.0], dtype='t CO2e/(t Steel)')
+        })
 
         for c in company_data:
             if c.company_id not in selected_company_ids:
                 continue
-            scope, expected_projection = expected_projections[c.company_id]
-            c_proj_targets = c.projected_targets[scope].projections
+            expected_column = expected_data[c.company_id]
+            scope_name = expected_column.columns[0]
+            expected_projection = expected_column[scope_name]
+            c_proj_targets = c.projected_targets[scope_name].projections
             if isinstance(c_proj_targets, pd.Series):
                 c_proj_targets = c_proj_targets[c_proj_targets.index>=2022]
-                assert [round(x, 4) for x in ITR.nominal_values(c_proj_targets.pint.m)] == expected_projection
+                assert_pint_series_equal(self, c_proj_targets, expected_projection, places=4)
             else:
                 while c_proj_targets[0].year < 2022:
+                    # c_proj_targets is a list of nasty BaseModel types so we cannot use Pandas asserters
                     c_proj_targets = c_proj_targets[1:]
-                    assert [ITR.nominal_values(round(x.value.m,4)) for x in c_proj_targets] == expected_projection
-            
-
+                    assert [ITR.nominal_values(round(x.value.m_as(expected_projection.dtype.units),4)) for x in c_proj_targets] == expected_projection.pint.m.tolist()
+     
     def test_temp_score(self):
         df_portfolio = pd.read_excel(self.company_data_path, sheet_name="Portfolio")
         requantify_df_from_columns(df_portfolio, inplace=True)

--- a/test/utils.py
+++ b/test/utils.py
@@ -39,10 +39,14 @@ def assert_pint_series_equal(case: unittest.case, left: pd.Series, right: pd.Ser
     left_values = left.tolist()
     right_values = right.tolist()
     for i, value in enumerate(left_values):
-        case.assertAlmostEqual(value, right_values[i].to(value.u), places, msg, delta)
+        case.assertAlmostEqual(ITR.nominal_values(value.m),
+                               ITR.nominal_values(right_values[i].to(value.u).m),
+                               places, msg, delta)
 
     for i, value in enumerate(right_values):
-        case.assertAlmostEqual(value, left_values[i].to(value.u), places, msg, delta)
+        case.assertAlmostEqual(ITR.nominal_values(value.m),
+                               ITR.nominal_values(left_values[i].to(value.u).m),
+                               places, msg, delta)
 
 
 def assert_pint_frame_equal(case: unittest.case, left: pd.DataFrame, right: pd.DataFrame, places=7, msg=None, delta=None):
@@ -53,7 +57,9 @@ def assert_pint_frame_equal(case: unittest.case, left: pd.DataFrame, right: pd.D
     errors = []
     for d, data in enumerate(left_flat):
         try:
-            case.assertAlmostEqual(data, right_flat[d], places, msg, delta)
+            case.assertAlmostEqual(ITR.nominal_values(data.m),
+                                   ITR.nominal_values(right_flat[d].to(data.u).m),
+                                   places, msg, delta)
         except AssertionError as e:
             errors.append(e.args[0])
     if errors:
@@ -61,7 +67,9 @@ def assert_pint_frame_equal(case: unittest.case, left: pd.DataFrame, right: pd.D
 
     for d, data in enumerate(right_flat):
         try:
-            case.assertAlmostEqual(data, left_flat[d], places, msg, delta)
+            case.assertAlmostEqual(ITR.nominal_values(data.m),
+                                   ITR.nominal_values(left_flat[d].to(data.u).m),
+                                   places, msg, delta)
         except AssertionError as e:
             errors.append((e.args[0]))
     if errors:


### PR DESCRIPTION
When subtracting two "identical" numbers that have error terms, the nominal term goes to zero, but the error actually grows (if it was nonzero).  Rather than stripping units before testing equality of nominal magnitudes, we fix the functions in utils.py to compare nominal values of properly aligned pint type magnitudes.

Other testing/uncertainty inconsistencies fixed.