### PR TITLE
Fix string-handling bugs

### DIFF
--- a/ITR/data/base_providers.py
+++ b/ITR/data/base_providers.py
@@ -395,11 +395,13 @@ class BaseCompanyDataProvider(CompanyDataProvider):
             new_company_projections = EITrajectoryProjector(self.projection_controls).project_ei_trajectories(
                 companies_without_projections)
             for c in new_company_projections:
+                production_units = c.base_year_production.units
                 if c.projected_intensities.S1S2 is None:
                     # When Gas Utilities split out S3, they often don't drag along S1S2 (and S3 are the biggies anyway)
-                    c.base_year_production = c.ghg_s3 / c.projected_intensities.S3.projections[base_year]
+                    production_value = c.ghg_s3 / c.projected_intensities.S3.projections[base_year]
                 else:
-                    c.base_year_production = c.ghg_s1s2 / c.projected_intensities.S1S2.projections[base_year]
+                    production_value = c.ghg_s1s2 / c.projected_intensities.S1S2.projections[base_year]
+                c.base_year_production = production_value.to(production_units)
                 if not ITR.isna(c.base_year_production):
                     for i, p in enumerate(c.historic_data.productions):
                         if p.year == base_year:
@@ -1146,7 +1148,7 @@ class EITargetProjector(EIProjector):
             # a netzero target for S1+S2 implies netzero targets for both S1 and S2.  The TPI benchmark needs an S1 target
             # for some sectors, and projecting a netzero target for S1 from S1+S2 makes that benchmark useable.
             # Note that we can only infer separate S1 and S2 targets from S1+S2 targets when S1+S2 = 0, because S1=0 + S2=0 is S1+S2=0
-            if not scope_targets:
+            if no_scope_targets:
                 if company.historic_data is None:
                     # This just defends against poorly constructed test cases
                     nz_target_years[scope_name] = None

--- a/ITR/data/template.py
+++ b/ITR/data/template.py
@@ -77,8 +77,6 @@ def _estimated_value(y: pd.Series) -> pint.Quantity:
         It could be changed to output the last (most recent) value (if the inputs arrive sorted)
     """
 
-    # if 'DE0005190003' in y.index:
-    #     breakpoint()
     try:
         if isinstance(y, pd.DataFrame):
             # Something went wrong with the GroupBy operation and we got a pd.DataFrame
@@ -356,7 +354,7 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
             # Make sure that if all NaN these columns are not represented as float64
             df_esg.submetric = df_esg.submetric.astype('string').str.strip().fillna('')
             if 'boundary' in df_esg.columns:
-                df_esg['boundary'] = df_esg['boundary'].str.strip().fillna('').astype('string')
+                df_esg['boundary'] = df_esg['boundary'].astype('string').str.strip().fillna('')
             # In the V2 template, the COMPANY_NAME and COMPANY_ID are merged cells and need to be filled forward
             # For convenience, we also fill forward Report Date, which is often expressed in the first row of a fresh report,
             # but sometimes omitted in subsequent rows (because it's "redundant information")
@@ -686,9 +684,9 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
 
             # convert "nice" word descriptions of S3 emissions to category numbers
             s3_idx = df_esg.metric.str.upper().eq('S3')
-            s3_dict_matches = df_esg[s3_idx].submetric.astype('str').str.lower().isin(s3_category_dict)
+            s3_dict_matches = df_esg[s3_idx].submetric.astype('string').str.lower().isin(s3_category_dict)
             s3_dict_idx = s3_dict_matches[s3_dict_matches].index
-            df_esg.loc[s3_dict_idx, 'submetric'] = df_esg.loc[s3_dict_idx].submetric.astype('str').str.lower().map(s3_category_dict)
+            df_esg.loc[s3_dict_idx, 'submetric'] = df_esg.loc[s3_dict_idx].submetric.astype('string').str.lower().map(s3_category_dict)
             # FIXME: can we make more efficient by just using ':' as index on left-hand side?
             df_esg.loc[s3_idx.index.difference(s3_dict_idx), 'submetric'] = df_esg.loc[s3_idx.index.difference(s3_dict_idx)].submetric.map(maybe_other_s3_mappings)
 


### PR DESCRIPTION
A previous fix for string-handling bugs missed a few cases.

Also keep production units consistent when re-calculating values based on intensity.