### PR TITLE
Speed up template test cases

### DIFF
--- a/test/test_template_provider.py
+++ b/test/test_template_provider.py
@@ -15,12 +15,8 @@ from ITR.data.data_warehouse import DataWarehouse
 from utils import assert_pint_series_equal, assert_pint_frame_equal
 
 
-class TestTemplateProvider(unittest.TestCase):
-    """
-    Test the excel template provider
-    """
-
-    def setUp(self) -> None:
+class TemplateV1:
+    def __init__(self) -> None:
         self.root = os.path.dirname(os.path.abspath(__file__))
         self.company_data_path = os.path.join(self.root, "inputs", "20220215 ITR Tool Sample Data.xlsx")
         self.sector_data_path = os.path.join(self.root, "inputs", "benchmark_OECM_PC.xlsx")
@@ -42,7 +38,24 @@ class TestTemplateProvider(unittest.TestCase):
             index=pd.Index(self.company_ids, name='company_id'),
             columns=[ColumnsConfig.SECTOR, ColumnsConfig.REGION, ColumnsConfig.SCOPE,
                      ColumnsConfig.BASE_EI, ColumnsConfig.BASE_YEAR_PRODUCTION, ColumnsConfig.PRODUCTION_METRIC])
-        self.company_info_at_base_year['ghg_s1s2'] = self.company_info_at_base_year.base_year_production.mul(self.company_info_at_base_year.ei_at_base_year)
+        self.company_info_at_base_year['ghg_s1s2'] = self.company_info_at_base_year.base_year_production.mul(self.company_info_at_base_year.ei_at_base_year)    
+
+template_V1 = TemplateV1()
+
+class TestTemplateProvider(unittest.TestCase):
+    """
+    Test the excel template provider
+    """
+
+    def setUp(self) -> None:
+        self.company_data_path = template_V1.company_data_path
+        self.sector_data_path = template_V1.sector_data_path
+        self.excel_production_bm = template_V1.excel_production_bm
+        self.excel_EI_bm = template_V1.excel_EI_bm
+        self.template_company_data = template_V1.template_company_data
+        self.data_warehouse = template_V1.data_warehouse
+        self.company_ids = template_V1.company_ids
+        self.company_info_at_base_year = template_V1.company_info_at_base_year
 
     def test_target_projections(self):
         comids = ['US00130H1059', 'US0185223007',

--- a/test/test_template_v2.py
+++ b/test/test_template_v2.py
@@ -22,26 +22,22 @@ pd.options.display.width=999
 pd.options.display.max_columns=99
 pd.options.display.min_rows=30
 
-class TestTemplateProviderV2(unittest.TestCase):
-    """
-    Test the excel template provider
-    """
-
-    def setUp(self) -> None:
-        self.root = os.path.dirname(os.path.abspath(__file__))
-        self.company_data_path = os.path.join(self.root, "inputs", "20220927 ITR V2 Sample Data.xlsx")
-        # self.company_data_path = os.path.join(self.root, "inputs", "20230106 ITR V2 Sample Data.xlsx")
+class TemplateV2:
+    def __init__(self) -> None:
+        root = os.path.dirname(os.path.abspath(__file__))
+        self.company_data_path = os.path.join(root, "inputs", "20220927 ITR V2 Sample Data.xlsx")
+        # self.company_data_path = os.path.join(root, "inputs", "20230106 ITR V2 Sample Data.xlsx")
         self.template_company_data = TemplateProviderCompany(excel_path=self.company_data_path)
         # load production benchmarks
-        self.benchmark_prod_json = os.path.join(self.root, "inputs", "json", "benchmark_production_OECM.json")
-        with open(self.benchmark_prod_json) as json_file:
+        benchmark_prod_json = os.path.join(root, "inputs", "json", "benchmark_production_OECM.json")
+        with open(benchmark_prod_json) as json_file:
             parsed_json = json.load(json_file)
         prod_bms = IProductionBenchmarkScopes.parse_obj(parsed_json)
         self.base_production_bm = BaseProviderProductionBenchmark(production_benchmarks=prod_bms)
 
         # load intensity benchmarks
-        self.benchmark_EI_json = os.path.join(self.root, "inputs", "json", "benchmark_EI_OECM_PC.json")
-        with open(self.benchmark_EI_json) as json_file:
+        benchmark_EI_json = os.path.join(root, "inputs", "json", "benchmark_EI_OECM_PC.json")
+        with open(benchmark_EI_json) as json_file:
             parsed_json = json.load(json_file)
         ei_bms = IEIBenchmarkScopes.parse_obj(parsed_json)
         self.base_EI_bm = BaseProviderIntensityBenchmark(EI_benchmarks=ei_bms)
@@ -50,6 +46,21 @@ class TestTemplateProviderV2(unittest.TestCase):
         self.company_ids = ["US00130H1059", "US26441C2044", "KR7005490008"]
         self.company_info_at_base_year = self.template_company_data.get_company_intensity_and_production_at_base_year(self.company_ids)
 
+template_V2 = TemplateV2()
+
+class TestTemplateProviderV2(unittest.TestCase):
+    """
+    Test the excel template provider
+    """
+
+    def setUp(self) -> None:
+        self.company_data_path = template_V2.company_data_path
+        self.template_company_data = template_V2.template_company_data
+        self.base_production_bm = template_V2.base_production_bm
+        self.base_EI_bm = template_V2.base_EI_bm
+        self.data_warehouse = template_V2.data_warehouse
+        self.company_ids = template_V2.company_ids
+        self.company_info_at_base_year = template_V2.company_info_at_base_year
 
     def test_target_projections(self):
         comids = ['US00130H1059', 'US0185223007',


### PR DESCRIPTION
Speed up template test cases by instantiating the template data object once and reusing it in all the various test cases.  This reduces running time of ALL test cases from more than 9 minutes to about 4 minutes.