### PR TITLE
Changes for version 1.0.5

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
     name: Check example notebooks
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
     name: Run unit tests
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,10 @@ numpy==1.24.3
 openpyxl==3.0.10
 openscm-units==0.5.2
 orca==1.8
-osc-ingest-tools==0.4.3
-pandas==2.0.3
+osc-ingest-tools>=0.4.3
+pandas>=2.0.3
 Pint>=0.22
-Pint-Pandas>=0.3
+Pint-Pandas>=0.5
 psutil==5.9.5
 pydantic==1.10.8
 pygithub==1.55

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="ITR",
-    version="1.0.4",
+    version="1.0.5",
     description="Assess the temperature alignment of current targets, commitments, "
     "and investment and lending portfolios.",
     long_description=long_description,
@@ -47,10 +47,10 @@ setup(
         "openpyxl==3.0.10",
         "openscm-units==0.5.2",
         "orca==1.8",
-        "osc-ingest-tools==0.4.3",
+        "osc-ingest-tools>=0.4.3",
         "pandas>=2.0.3",
         "Pint>=0.22",
-        "Pint-Pandas>=0.3",
+        "Pint-Pandas>=0.5",
         "psutil==5.9.5",
         "pydantic==1.10.8",
         "pygithub==1.55",
@@ -84,6 +84,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development",
         "Topic :: Office/Business :: Financial",


### PR DESCRIPTION
Re-enable Python 3.11 build and test.

Update requirements to allow for Pandas 2.1.0 by requiring Pint-Pandas 0.5.

Anticipate new releases of osc-ingest-tools.