### PR TITLE
Update security-audit.yaml

### DIFF
--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -36,3 +36,6 @@ jobs:
 
       - name: "Run: pip-audit"
         uses: pypa/gh-action-pip-audit@v1.0.8
+        with:
+          ignore-vulns: |
+            PYSEC-2023-163


### PR DESCRIPTION
Ignore bogus CVE flagging a library required by Pandas that we do not expose in the ITR tool.