### PR TITLE
Fix some errors in error reporting

### DIFF
--- a/src/ITR/data/osc_units.py
+++ b/src/ITR/data/osc_units.py
@@ -486,7 +486,7 @@ EI_Quantity = Annotated[Quantity, BeforeValidator(to_Quantity), AfterValidator(c
 
 
 def check_BenchmarkQuantity(quantity: Quantity) -> Quantity:
-    if str(quantity.u) == "dimensionless":
+    if quantity.u.dimensionless:
         return quantity
     for ei_u in _ei_units:
         if quantity.is_compatible_with(ei_u):

--- a/src/ITR/data/template.py
+++ b/src/ITR/data/template.py
@@ -344,14 +344,18 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
             )
             if "boundary" in df1.columns:
                 df1.drop(columns="boundary", inplace=True)
-            df1 = df1.drop(columns="unit").groupby(
-                by=[
-                    ColumnsConfig.COMPANY_ID,
-                    ColumnsConfig.TEMPLATE_REPORT_DATE,
-                    "submetric",
-                ],
-                dropna=False,
-            ).agg(_estimated_value)
+            df1 = (
+                df1.drop(columns="unit")
+                .groupby(
+                    by=[
+                        ColumnsConfig.COMPANY_ID,
+                        ColumnsConfig.TEMPLATE_REPORT_DATE,
+                        "submetric",
+                    ],
+                    dropna=False,
+                )
+                .agg(_estimated_value)
+            )
             df1["sub_count"] = df1.groupby([ColumnsConfig.COMPANY_ID, ColumnsConfig.TEMPLATE_REPORT_DATE])[
                 df1.columns[0]
             ].transform("count")
@@ -856,7 +860,7 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
             em_metrics_grouped = em_metrics.groupby(by=["company_id", "metric"])
             em_unit_nunique = em_metrics_grouped["unit"].nunique()
             if any(em_unit_nunique > 1):
-                em_unit_ambig = em_unit_nunique[em_unit_nunique > 1].reset_index('metric')
+                em_unit_ambig = em_unit_nunique[em_unit_nunique > 1].reset_index("metric")
                 for company_id in em_unit_ambig.index.unique():
                     logger.warning(
                         f"Company {company_id} uses multiple units describing scopes "


### PR DESCRIPTION
There was some confusion in how we found/reported ambiguous unit usage (i.e., a single metric being represented by multiple types of units).  I think this is now fixed.