### PR TITLE
Workaround for Pandas #55824

### DIFF
--- a/src/ITR/data/template.py
+++ b/src/ITR/data/template.py
@@ -854,7 +854,7 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
                     # Convert ints to float as Work-around for Pandas GH#55824
                     # If we remove this extra conversion, we'll need to change Q_(m, u) to Q_(float(m), u)
                     # so as to convert not-yet-numeric string values to floating point numbers
-                    df_esg[col] = df_esg[col].astype('float64')
+                    df_esg[col] = df_esg[col].astype("float64")
                     df_esg[col] = df_esg[col].combine(
                         u_col,
                         lambda m, u: PintType(u).na_value if ITR.isna(m) else Q_(m, u),

--- a/src/ITR/data/template.py
+++ b/src/ITR/data/template.py
@@ -851,9 +851,13 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
                 warnings.simplefilter("ignore")
                 u_col = df_esg["unit"]
                 for col in esg_year_columns:
+                    # Convert ints to float as Work-around for Pandas GH#55824
+                    # If we remove this extra conversion, we'll need to change Q_(m, u) to Q_(float(m), u)
+                    # so as to convert not-yet-numeric string values to floating point numbers
+                    df_esg[col] = df_esg[col].astype('float64')
                     df_esg[col] = df_esg[col].combine(
                         u_col,
-                        lambda m, u: PintType(u).na_value if ITR.isna(m) else Q_(float(m), u),
+                        lambda m, u: PintType(u).na_value if ITR.isna(m) else Q_(m, u),
                     )
             # All emissions metrics across multiple sectors should all resolve to some form of [mass] CO2
             em_metrics = df_esg[df_esg.metric.str.upper().isin(["S1", "S2", "S3", "S1S2", "S1S3", "S1S2S3"])]


### PR DESCRIPTION
Pandas gets tripped up when `int64` columns are fed into `pd.combine` to produce quantified units.  But it works fine with `float64` data, so convert everything to floats before adding units to create quantities.

Thanks to @FannySternfeld for finding this workaround!