### PR TITLE
reorder imports to ensure primacy of our Quantity

### DIFF
--- a/src/ITR/__init__.py
+++ b/src/ITR/__init__.py
@@ -2,17 +2,12 @@
 This package helps companies and financial institutions to assess the temperature alignment of investment and lending
 portfolios.
 """
-import warnings
 import pandas as pd
 import numpy as np
 import os
-import json
 from .interfaces import EScope
-from . import data
-from . import utils
-from . import temperature_score
+from . import data  # noqa F401
 import pint
-from pint_pandas import PintType, PintArray
 
 data_dir = os.path.join(__path__[0], "data", "json")
 
@@ -28,7 +23,7 @@ try:
     from .utils import umean
 
     HAS_UNCERTAINTIES = True
-except (ImportError, ModuleNotFoundError, AttributeError) as exc:
+except (ImportError, ModuleNotFoundError, AttributeError) as exc:  # noqa F841
     HAS_UNCERTAINTIES = False
     from numpy import isnan
     from statistics import mean
@@ -70,7 +65,7 @@ def Q_m_as(value, units, inplace=False):
     Returns the MAGNITUDE of the (possibly) converted value.
     """
     x = value
-    if type(value) == str:
+    if isinstance(value, str):
         x = pint.Quantity(value)
     if x.u == units:
         return x.m

--- a/src/ITR/configs.py
+++ b/src/ITR/configs.py
@@ -9,10 +9,9 @@ from typing import List
 from pydantic import BaseModel, ConfigDict
 from dataclasses import dataclass
 
+from .data.osc_units import Quantity_type, EmissionsQuantity
+
 import pandas as pd
-import pint
-import ITR
-from ITR.data.osc_units import ureg, Q_, Quantity_type, EmissionsQuantity
 
 
 def ITR_median(*args, **kwargs):

--- a/src/ITR/data/__init__.py
+++ b/src/ITR/data/__init__.py
@@ -7,8 +7,6 @@ from pint import set_application_registry
 from openscm_units import unit_registry
 import re
 
-import numpy as np
-
 currency_dict = {
     # 'US$':'USD', NOTE: don't try to re-define USD...it leads to infinite recursion
     "€": "EUR",
@@ -112,7 +110,7 @@ pint.Measurement = ureg.Measurement
 pint.Context = ureg.Context
 
 # FIXME: delay loading of pint_pandas until after we've initialized ourselves
-from pint_pandas import PintType, PintArray
+from pint_pandas import PintArray  # noqa E402
 
 Q_ = ureg.Quantity
 M_ = ureg.Measurement

--- a/src/ITR/data/data_providers.py
+++ b/src/ITR/data/data_providers.py
@@ -1,30 +1,25 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Dict, Union
+from typing import List
 import pandas as pd
 
-from pint import Quantity
-from ITR.data.osc_units import ureg
-
-from ITR.interfaces import (
-    ICompanyData,
-    EScope,
-    IHistoricData,
-    IProductionRealization,
-    IHistoricEmissionsScopes,
-    IHistoricEIScopes,
-    ICompanyEIProjection,
-    ICompanyEIProjectionsScopes,
-    ICompanyEIProjections,
+from ..configs import (  # noqa F401
+    ColumnsConfig,
 )
 
-from ITR.configs import (
-    TabsConfig,
-    ColumnsConfig,
-    VariablesConfig,
-    TemperatureScoreControls,
-    TemperatureScoreConfig,
+from ..data.osc_units import Quantity
+
+from ..interfaces import (  # noqa F401
+    EScope,
+    ICompanyData,
+    ICompanyEIProjection,
+    ICompanyEIProjections,
+    ICompanyEIProjectionsScopes,
+    IHistoricData,
+    IHistoricEIScopes,
+    IHistoricEmissionsScopes,
+    IProductionRealization,
 )
 
 

--- a/src/ITR/data/data_warehouse.py
+++ b/src/ITR/data/data_warehouse.py
@@ -7,14 +7,13 @@ from typing import List, Type
 from pydantic import ValidationError
 
 import ITR
-from . import ureg, Q_, PA_
-from ITR.data.osc_units import (
-    asPintSeries,
+from ..data import Q_, PA_
+from ..data.osc_units import (
     asPintDataFrame,
     EmissionsQuantity,
     Quantity_type,
 )
-from ITR.interfaces import (
+from ..interfaces import (
     EScope,
     IEmissionRealization,
     IEIRealization,
@@ -25,12 +24,12 @@ from ITR.interfaces import (
     DF_ICompanyEIProjections,
     IHistoricData,
 )
-from ITR.data.data_providers import (
+from ..data.data_providers import (
     CompanyDataProvider,
     ProductionBenchmarkDataProvider,
     IntensityBenchmarkDataProvider,
 )
-from ITR.configs import ColumnsConfig, LoggingConfig, ProjectionControls
+from ..configs import ColumnsConfig, LoggingConfig
 
 import logging
 
@@ -38,7 +37,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 LoggingConfig.add_config_to_logger(logger)
 
-import pint
 from pint import DimensionalityError
 
 
@@ -617,8 +615,8 @@ class DataWarehouse(ABC):
             bm_ei_s1s2 = None
 
         if company.projected_intensities.S1S2S3:
-            assert company.projected_intensities.S1S2 == None
-            assert company.projected_intensities.S1 == None
+            assert company.projected_intensities.S1S2 is None
+            assert company.projected_intensities.S1 is None
             ei_metric = company.projected_intensities.S1S2S3.ei_metric
             s1s2_projections = company.projected_intensities.S1S2S3.projections * bm_ei_s1s2 / (bm_ei_s1s2 + bm_ei_s3)
             s3_projections = company.projected_intensities.S1S2S3.projections * bm_ei_s3 / (bm_ei_s1s2 + bm_ei_s3)
@@ -650,7 +648,7 @@ class DataWarehouse(ABC):
             # Penalize non-disclosure by assuming 2x aligned S3 emissions.  That's still likely undercounting, because
             # most non-disclosing companies are nowhere near the reduction rates of the benchmarks.
             # It would be lovely to use S1S2 or S1 data to inform S3, but that likely adds error on top of error
-            assert company.projected_intensities.S1S2S3 == None
+            assert company.projected_intensities.S1S2S3 is None
             ei_metric = str(bm_ei_s3.dtype.units)
             # If we don't have uncertainties, ITR.ufloat just returns the nom value 2.0
             s3_projections = bm_ei_s3 * ITR.ufloat(2.0, 1.0)

--- a/src/ITR/data/excel.py
+++ b/src/ITR/data/excel.py
@@ -5,34 +5,26 @@ import numpy as np
 
 from pydantic import BaseModel, ValidationError
 
-from . import ureg, Q_
-from ITR.data.osc_units import (
-    BenchmarkMetric,
-    EmissionsQuantity,
-    EI_Quantity,
-    Quantity_type,
-)
-
-from ITR.configs import (
+from ..configs import (
     ColumnsConfig,
-    TemperatureScoreConfig,
     VariablesConfig,
     TabsConfig,
     ProjectionControls,
     LoggingConfig,
 )
-
-import logging
-
-logger = logging.getLogger(__name__)
-LoggingConfig.add_config_to_logger(logger)
-
-from ITR.data.base_providers import (
+from ..data import Q_
+from ..data.base_providers import (
     BaseCompanyDataProvider,
     BaseProviderProductionBenchmark,
     BaseProviderIntensityBenchmark,
 )
-from ITR.interfaces import (
+from ..data.osc_units import (
+    BenchmarkMetric,
+    EmissionsQuantity,
+    EI_Quantity,
+    Quantity_type,
+)
+from ..interfaces import (
     ICompanyData,
     ICompanyEIProjection,
     EScope,
@@ -51,6 +43,11 @@ from ITR.interfaces import (
     UProjection,
     IProjection,
 )
+
+import logging
+
+logger = logging.getLogger(__name__)
+LoggingConfig.add_config_to_logger(logger)
 
 
 # Excel spreadsheets don't have units elaborated, so we translate sectors to units
@@ -469,7 +466,7 @@ class ExcelProviderCompany(BaseCompanyDataProvider):
         :param historic_data: Dataframe Productions, Emissions, and Emissions Intensities mixed together
         :return: historic data with unit attributes added on a per-element basis
         """
-        self.historic_years = [column for column in historic_data.columns if type(column) == int]
+        self.historic_years = [column for column in historic_data.columns if isinstance(column, int)]
 
         missing_ids = [company_id for company_id in company_ids if company_id not in historic_data.index]
         if missing_ids:

--- a/src/ITR/data/osc_units.py
+++ b/src/ITR/data/osc_units.py
@@ -2,12 +2,16 @@
 This module handles initialization of pint functionality
 """
 
+import ITR
+from ..data import PA_, Q_, ureg
+
 import re
-import json
 
 from dataclasses import dataclass
 from typing import Annotated, Any, Dict
+
 from pydantic_core import CoreSchema, core_schema
+
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -19,16 +23,12 @@ from pydantic import (
 from pydantic.json_schema import JsonSchemaValue
 from pydantic.functional_validators import BeforeValidator, AfterValidator
 
-import numpy as np
 import pandas as pd
 import pint
-from pint import get_application_registry, Context, Quantity, DimensionalityError
-from pint.facets.plain import PlainUnit
-
-import ITR
-from . import ureg, Q_, M_, PA_
-
+from pint import Context, DimensionalityError
 from pint_pandas import PintType
+
+Quantity = ureg.Quantity
 
 ureg.define("CO2e = CO2 = CO2eq = CO2_eq")
 # openscm_units does this for all gas species...we just have to keep up.

--- a/src/ITR/interfaces.py
+++ b/src/ITR/interfaces.py
@@ -1,6 +1,23 @@
 from __future__ import annotations
 
-import json
+import ITR
+from .configs import ProjectionControls, LoggingConfig
+from .data.osc_units import (
+    ureg,
+    Q_,
+    PA_,
+    BenchmarkMetric,
+    BenchmarkQuantity,
+    ProductionMetric,
+    ProductionQuantity,
+    EmissionsMetric,
+    EmissionsQuantity,
+    EI_Metric,
+    EI_Quantity,
+    MonetaryQuantity,
+    Quantity_type,
+)
+
 import numpy as np
 import pandas as pd
 
@@ -19,35 +36,14 @@ from pydantic import (
 )
 from pydantic.json_schema import JsonSchemaValue
 
-import ITR
-
-from ITR.data.osc_units import (
-    ureg,
-    Q_,
-    M_,
-    PA_,
-    BenchmarkMetric,
-    BenchmarkQuantity,
-    ProductionMetric,
-    ProductionQuantity,
-    EmissionsMetric,
-    EmissionsQuantity,
-    EI_Metric,
-    EI_Quantity,
-    MonetaryQuantity,
-    Quantity_type,
-)
-from ITR.configs import ProjectionControls, LoggingConfig
-
 import logging
+
+from pint_pandas import PintType
+from pint_pandas.pint_array import PintSeriesAccessor
+
 
 logger = logging.getLogger(__name__)
 LoggingConfig.add_config_to_logger(logger)
-
-import pint
-from pint.errors import DimensionalityError
-from pint_pandas import PintType
-from pint_pandas.pint_array import PintSeriesAccessor
 
 
 class SortableEnum(Enum):
@@ -689,7 +685,6 @@ class ICompanyData(BaseModel):
             "Residential Buildings": {"Global": "billion m**2"},  # Should it be 'built m**2' ?
             "Commercial Buildings": {"Global": "billion m**2"},  # Should it be 'built m**2' ?
             "Textiles": {"Global": "billion USD"},
-            "Chemicals": {"Global": "billion USD"},
             "Chemicals": {"Global": "billion USD"},
             "Pharmaceuticals": {"Global": "billion USD"},
             "Ag Chem": {"Global": "billion USD"},

--- a/src/ITR/portfolio_aggregation.py
+++ b/src/ITR/portfolio_aggregation.py
@@ -1,27 +1,23 @@
+import ITR
+from .configs import PortfolioAggregationConfig, ColumnsConfig, LoggingConfig
+from .data.osc_units import asPintSeries, PA_
+from .interfaces import EScope
+
 from abc import ABC
 from enum import Enum
 import warnings  # needed until apply behaves better with Pint quantities in arrays
 
 from typing import Type
 
-from pint import Quantity
-from pint_pandas import PintType
-
 import numpy as np
 import pandas as pd
-import pint
-import pint_pandas
-
-import ITR
-from .data.osc_units import asPintSeries, Q_, PA_
-from .configs import PortfolioAggregationConfig, ColumnsConfig, LoggingConfig
+from pint_pandas import PintType
 
 import logging
 
+
 logger = logging.getLogger(__name__)
 LoggingConfig.add_config_to_logger(logger)
-
-from .interfaces import EScope
 
 
 class PortfolioAggregationMethod(Enum):

--- a/src/ITR/temperature_score.py
+++ b/src/ITR/temperature_score.py
@@ -1,14 +1,7 @@
-import warnings  # needed until apply behaves better with Pint quantities in arrays
-
-from typing import Optional, Tuple, Type, List
-
-import pandas as pd
-import numpy as np
-import itertools
-
 import ITR
-from .data.osc_units import ureg, Q_, PA_, Quantity_type
-
+from .configs import TemperatureScoreConfig, ColumnsConfig, LoggingConfig
+from .data.data_warehouse import DataWarehouse
+from .data.osc_units import ureg, Q_, Quantity_type
 from .interfaces import (
     EScope,
     ETimeFrames,
@@ -21,15 +14,19 @@ from .interfaces import (
     PortfolioCompany,
 )
 from .portfolio_aggregation import PortfolioAggregation, PortfolioAggregationMethod
-from .configs import TemperatureScoreConfig, ColumnsConfig, LoggingConfig
+
+import warnings  # needed until apply behaves better with Pint quantities in arrays
+
+from typing import Optional, Tuple, Type, List
+
+import pandas as pd
+import numpy as np
+import itertools
 
 import logging
 
 logger = logging.getLogger(__name__)
 LoggingConfig.add_config_to_logger(logger)
-
-from . import utils
-from .data.data_warehouse import DataWarehouse
 
 
 class TemperatureScore(PortfolioAggregation):
@@ -334,13 +331,15 @@ class TemperatureScore(PortfolioAggregation):
             target_probability = TemperatureScoreConfig.CONTROLS_CONFIG.target_probability
         if data is None:
             if data_warehouse is not None and portfolio is not None:
+                from . import utils
+
                 data = utils.get_data(data_warehouse, portfolio)
             else:
                 raise ValueError("You need to pass and either a data set or a datawarehouse and companies")
 
-        logger.info(f"temperature score preparing data")
+        logger.info("temperature score preparing data")
         data = self._prepare_data(data, target_probability)
-        logger.info(f"temperature score data prepared")
+        logger.info("temperature score data prepared")
 
         if self.scopes:
             if EScope.S1S2S3 in self.scopes:
@@ -468,7 +467,7 @@ class TemperatureScore(PortfolioAggregation):
             for group_names, group in grouped_data:
                 group_name_joined = (
                     group_names
-                    if type(group_names) == str
+                    if isinstance(group_names, str)
                     else "-".join([str(group_name) for group_name in group_names])
                 )
                 (

--- a/src/ITR/utils.py
+++ b/src/ITR/utils.py
@@ -1,32 +1,28 @@
 from __future__ import annotations
 
-import sys
-import pandas as pd
-import numpy as np
-from pathlib import Path
-from typing import List, Optional, Tuple
-
 import ITR
-from ITR.data.osc_units import ureg, Q_, asPintSeries
-import pint
-from pint_pandas import PintType
-
-from .interfaces import PortfolioCompany, EScope, ETimeFrames, ScoreAggregations
 from .configs import (
     ColumnsConfig,
     TemperatureScoreControls,
     TemperatureScoreConfig,
     LoggingConfig,
 )
+from .data.data_warehouse import DataWarehouse
+from .data.osc_units import Q_, Quantity, asPintSeries
+from .interfaces import PortfolioCompany, EScope, ETimeFrames, ScoreAggregations
+from .portfolio_aggregation import PortfolioAggregationMethod
+from .temperature_score import TemperatureScore
+
+import sys
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from typing import List, Optional, Tuple
 
 import logging
 
 logger = logging.getLogger(__name__)
 LoggingConfig.add_config_to_logger(logger)
-
-from .data.data_warehouse import DataWarehouse
-from .portfolio_aggregation import PortfolioAggregationMethod
-from .temperature_score import TemperatureScore
 
 
 # If this file is moved, the computation of get_project_root may also need to change
@@ -155,7 +151,7 @@ def get_data(data_warehouse: DataWarehouse, portfolio: List[PortfolioCompany]) -
 
 def calculate(
     portfolio_data: pd.DataFrame,
-    fallback_score: pint.Quantity["delta_degC"],
+    fallback_score: Quantity["delta_degC"],
     aggregation_method: PortfolioAggregationMethod,
     grouping: Optional[List[str]],
     time_frames: List[ETimeFrames],

--- a/test/generate_fundamental_data.py
+++ b/test/generate_fundamental_data.py
@@ -6,33 +6,26 @@ from numpy.testing import assert_array_equal
 
 import ITR
 from ITR import data_dir
-from ITR.interfaces import EScope, ETimeFrames, IntensityMetric
-from ITR.interfaces import (
-    ICompanyData,
-    ICompanyEIProjectionsScopes,
-    ICompanyEIProjections,
-    ICompanyEIProjection,
-)
-from ITR.interfaces import (
-    IProductionBenchmarkScopes,
-    IEIBenchmarkScopes,
-    PortfolioCompany,
-)
-
 from ITR.data.base_providers import (
     BaseCompanyDataProvider,
     BaseProviderProductionBenchmark,
     BaseProviderIntensityBenchmark,
 )
-
 from ITR.data.data_warehouse import DataWarehouse
-from ITR.temperature_score import TemperatureScore
+from ITR.interfaces import (
+    EScope,
+    ETimeFrames,
+    ICompanyData,
+    IEIBenchmarkScopes,
+    IProductionBenchmarkScopes,
+    PortfolioCompany,
+)
 from ITR.portfolio_aggregation import PortfolioAggregationMethod
+from ITR.temperature_score import TemperatureScore
 
-from pint import Quantity
-from ITR.data.osc_units import ureg, Q_, PA_
+from ITR.data.osc_units import ureg, Q_
 
-from utils import gen_company_data, DequantifyQuantity
+from utils import gen_company_data
 
 # from utils import ITR_Encoder
 

--- a/test/test_different_benchmarks.py
+++ b/test/test_different_benchmarks.py
@@ -2,38 +2,28 @@ import unittest
 import json
 import os
 import pandas as pd
-from numpy.testing import assert_array_equal
 
 import ITR
 from ITR import data_dir
-from ITR.interfaces import EScope, ETimeFrames
-from ITR.interfaces import (
-    ICompanyData,
-    ICompanyEIProjectionsScopes,
-    ICompanyEIProjections,
-    ICompanyEIProjection,
-)
-from ITR.interfaces import (
-    IProductionBenchmarkScopes,
-    IEIBenchmarkScopes,
-    PortfolioCompany,
-)
-
 from ITR.data.base_providers import (
     BaseCompanyDataProvider,
     BaseProviderProductionBenchmark,
     BaseProviderIntensityBenchmark,
 )
-
 from ITR.data.data_warehouse import DataWarehouse
-from ITR.temperature_score import TemperatureScore
+from ITR.data.osc_units import ureg, Q_, PA_
+from ITR.interfaces import (
+    EScope,
+    ETimeFrames,
+    ICompanyData,
+    IEIBenchmarkScopes,
+    IProductionBenchmarkScopes,
+    PortfolioCompany,
+)
 from ITR.portfolio_aggregation import PortfolioAggregationMethod
+from ITR.temperature_score import TemperatureScore
 
-from pint import Quantity
-from pint_pandas import PintType
-from ITR.data.osc_units import ureg, Q_, PA_, asPintSeries, asPintDataFrame
-
-from utils import gen_company_data, DequantifyQuantity, assert_pint_series_equal
+from utils import gen_company_data, assert_pint_series_equal
 
 # For this test case, we prime the pump with known-aligned emissions intensities.
 # We can then construct companies that have some passing resemplemnce to these, and then verify alignment/non-alignment

--- a/test/test_e2e.py
+++ b/test/test_e2e.py
@@ -3,23 +3,16 @@ import copy
 from typing import List
 
 import ITR
-from ITR.data.osc_units import ureg, Q_, PA_
-
+from ITR.data.data_warehouse import DataWarehouse
+from ITR.data.osc_units import ureg, Q_
 from ITR.interfaces import (
     EScope,
     ETimeFrames,
     PortfolioCompany,
 )
-
-from ITR.temperature_score import TemperatureScore
 from ITR.portfolio_aggregation import PortfolioAggregationMethod
-from ITR.data.data_providers import (
-    CompanyDataProvider,
-    ProductionBenchmarkDataProvider,
-    IntensityBenchmarkDataProvider,
-)
-from ITR.data.data_warehouse import DataWarehouse
-from ITR.interfaces import ICompanyAggregates, ICompanyEIProjectionsScopes, IProjection
+from ITR.temperature_score import TemperatureScore
+from ITR.interfaces import ICompanyAggregates, ICompanyEIProjectionsScopes
 
 
 class e2e_DataProvider:  # if derived from CompanyDataProvider, we'd have to provide implementations for several methods we never use

--- a/test/test_excel_provider.py
+++ b/test/test_excel_provider.py
@@ -3,18 +3,18 @@ import unittest
 import pandas as pd
 
 import ITR
+from ITR.configs import ColumnsConfig, TemperatureScoreConfig
+from ITR.data.data_warehouse import DataWarehouse
 from ITR.data.excel import (
     ExcelProviderCompany,
     ExcelProviderProductionBenchmark,
     ExcelProviderIntensityBenchmark,
 )
-from ITR.data.data_warehouse import DataWarehouse
-from ITR.configs import ColumnsConfig, TemperatureScoreConfig
+from ITR.data.osc_units import Q_, asPintSeries, ureg
 from ITR.interfaces import EScope, ETimeFrames, PortfolioCompany
-from ITR.temperature_score import TemperatureScore
 from ITR.portfolio_aggregation import PortfolioAggregationMethod
+from ITR.temperature_score import TemperatureScore
 
-from ITR.data.osc_units import ureg, Q_, PA_, asPintSeries
 from test_base_providers import assert_pint_frame_equal, assert_pint_series_equal
 
 

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -1,24 +1,19 @@
-import os
 import unittest
 
 import pandas as pd
 
-import ITR
+import ITR  # noqa F401
+from ITR.configs import TemperatureScoreConfig
 from ITR.data.osc_units import (
-    ureg,
     Q_,
-    PA_,
     BenchmarkMetric,
     ProductionMetric,
     EI_Metric,
-    BenchmarkQuantity,
     EI_Quantity,
 )
-from ITR.configs import TemperatureScoreConfig
 from ITR.interfaces import (
     EScope,
     UProjection,
-    IProjection,
     IBenchmark,
     ICompanyData,
     ICompanyEIProjectionsScopes,

--- a/test/test_portfolio_aggregation.py
+++ b/test/test_portfolio_aggregation.py
@@ -1,11 +1,11 @@
 import unittest
 import numpy as np
 import pandas as pd
-import ITR
-from utils import assert_pint_series_equal
-from ITR.portfolio_aggregation import PortfolioAggregationMethod, PortfolioAggregation
+import ITR  # noqa F401
 from ITR.configs import ColumnsConfig
 from ITR.interfaces import EScope
+from ITR.portfolio_aggregation import PortfolioAggregationMethod, PortfolioAggregation
+from utils import assert_pint_series_equal
 
 
 class TestPortfolioAggregation(unittest.TestCase):

--- a/test/test_projection.py
+++ b/test/test_projection.py
@@ -6,16 +6,15 @@ from typing import List
 import warnings
 import pandas as pd
 
-import ITR
+import ITR  # noqa F401
 from ITR import data_dir
-from utils import ITR_Encoder, assert_pint_series_equal
-from ITR.data.osc_units import Q_, PA_, asPintDataFrame
 from ITR.configs import ColumnsConfig, VariablesConfig
 from ITR.data.base_providers import (
     BaseProviderProductionBenchmark,
     EITrajectoryProjector,
     EITargetProjector,
 )
+from ITR.data.osc_units import Q_, PA_, asPintDataFrame
 from ITR.interfaces import (
     EScope,
     ICompanyData,
@@ -23,6 +22,7 @@ from ITR.interfaces import (
     IProductionBenchmarkScopes,
     ITargetData,
 )
+from utils import ITR_Encoder, assert_pint_series_equal
 
 
 def is_pint_dict_equal(result: List[dict], reference: List[dict]) -> bool:
@@ -251,7 +251,7 @@ class TestProjector(unittest.TestCase):
         historic_df = ei_projector._extract_historic_df(fillna_data)
         ei_projector._align_and_compute_missing_historic_ei(fillna_data, historic_df)
 
-        historic_years = [column for column in historic_df.columns if type(column) == int]
+        historic_years = [column for column in historic_df.columns if isinstance(column, int)]
         projection_years = range(max(historic_years), ei_projector.projection_controls.TARGET_YEAR + 1)
         with warnings.catch_warnings():
             # Don't worry about warning that we are intentionally dropping units as we transpose

--- a/test/test_targets.py
+++ b/test/test_targets.py
@@ -3,42 +3,27 @@ import json
 import os
 import re
 import pandas as pd
-import numpy as np
-from numpy.testing import assert_array_equal
 
-import ITR
+import ITR  # noqa F401
 from ITR import data_dir
-from ITR.interfaces import EScope, ETimeFrames
-from ITR.interfaces import (
-    ICompanyData,
-    ICompanyEIProjectionsScopes,
-    ICompanyEIProjections,
-    ICompanyEIProjection,
-)
-from ITR.interfaces import (
-    IProductionBenchmarkScopes,
-    IEIBenchmarkScopes,
-    PortfolioCompany,
-    ITargetData,
-)
-
+from ITR.configs import ColumnsConfig
 from ITR.data.base_providers import (
     BaseCompanyDataProvider,
     BaseProviderProductionBenchmark,
     BaseProviderIntensityBenchmark,
     EITargetProjector,
-    EITrajectoryProjector,
+)
+from ITR.data.data_warehouse import DataWarehouse
+from ITR.data.osc_units import Q_, PA_, asPintDataFrame
+from ITR.interfaces import (
+    EScope,
+    ICompanyData,
+    IProductionBenchmarkScopes,
+    IEIBenchmarkScopes,
+    ITargetData,
 )
 
-from ITR.data.data_warehouse import DataWarehouse
-from ITR.temperature_score import TemperatureScore
-from ITR.portfolio_aggregation import PortfolioAggregationMethod
-
-from pint import Quantity
-from ITR.data.osc_units import ureg, Q_, PA_, asPintSeries, asPintDataFrame
-from ITR.configs import ColumnsConfig
-
-from utils import gen_company_data, DequantifyQuantity, assert_pint_series_equal
+from utils import gen_company_data, assert_pint_series_equal
 
 
 def print_expected(target_df, company_data):

--- a/test/test_temperature_score.py
+++ b/test/test_temperature_score.py
@@ -2,19 +2,17 @@ import warnings
 import os
 import unittest
 import pandas as pd
-import numpy as np
 
-import ITR
+import ITR  # noqa F401
 from ITR.configs import ColumnsConfig
 from ITR.interfaces import ETimeFrames, EScope
 from ITR.temperature_score import TemperatureScore
 from ITR.portfolio_aggregation import PortfolioAggregationMethod
 from ITR.data.osc_units import (
-    ureg,
     Q_,
-    asPintSeries,
-    requantify_df_from_columns,
     asPintDataFrame,
+    requantify_df_from_columns,
+    ureg,
 )
 from utils import assert_pint_series_equal
 

--- a/test/test_template_provider.py
+++ b/test/test_template_provider.py
@@ -1,21 +1,20 @@
 import os
 import unittest
-import numpy as np
 import pandas as pd
 
 import ITR
-from ITR.data.osc_units import ureg, Q_, asPintSeries, requantify_df_from_columns
 from ITR.configs import ColumnsConfig, TemperatureScoreConfig
-from ITR.interfaces import EScope, ETimeFrames, PortfolioCompany
-from ITR.temperature_score import TemperatureScore
-from ITR.portfolio_aggregation import PortfolioAggregationMethod
 from ITR.data.base_providers import EITargetProjector
+from ITR.data.data_warehouse import DataWarehouse
 from ITR.data.excel import (
     ExcelProviderProductionBenchmark,
     ExcelProviderIntensityBenchmark,
 )
+from ITR.data.osc_units import ureg, Q_, asPintSeries, requantify_df_from_columns
 from ITR.data.template import TemplateProviderCompany
-from ITR.data.data_warehouse import DataWarehouse
+from ITR.interfaces import EScope, ETimeFrames, PortfolioCompany
+from ITR.portfolio_aggregation import PortfolioAggregationMethod
+from ITR.temperature_score import TemperatureScore
 from utils import assert_pint_series_equal, assert_pint_frame_equal
 
 

--- a/test/test_template_v2.py
+++ b/test/test_template_v2.py
@@ -1,33 +1,29 @@
 import json
 import os
 import unittest
-from numpy.testing import assert_array_equal
-import pandas as pd
-from pint_pandas import PintArray as PA_
-
 import ITR
 from ITR import data_dir
-from ITR.data.osc_units import ureg, Q_, M_, asPintSeries, requantify_df_from_columns
 from ITR.configs import ColumnsConfig, TemperatureScoreConfig
-
 from ITR.data.base_providers import (
-    EITargetProjector,
     BaseProviderProductionBenchmark,
     BaseProviderIntensityBenchmark,
 )
-from ITR.data.template import TemplateProviderCompany
 from ITR.data.data_warehouse import DataWarehouse
+from ITR.data.osc_units import ureg, Q_, asPintSeries, requantify_df_from_columns
+from ITR.data.template import TemplateProviderCompany
 from ITR.interfaces import (
     EScope,
     ETimeFrames,
-    PortfolioCompany,
     IProductionBenchmarkScopes,
     IEIBenchmarkScopes,
 )
-from ITR.temperature_score import TemperatureScore
 from ITR.portfolio_aggregation import PortfolioAggregationMethod
+from ITR.temperature_score import TemperatureScore
 from utils import assert_pint_series_equal, assert_pint_frame_equal
 
+
+import pandas as pd
+from pint_pandas import PintArray as PA_
 
 pd.options.display.width = 999
 pd.options.display.max_columns = 99

--- a/test/test_vault_providers.py
+++ b/test/test_vault_providers.py
@@ -7,6 +7,21 @@ else:
     pytestmark = pytest.mark.skip
     pytest.skip("skipping vault because Trino auth breaks CI/CD", allow_module_level=True)
 
+import ITR  # noqa F401
+from ITR import data_dir
+from ITR.configs import ColumnsConfig, TemperatureScoreConfig
+from ITR.data.data_warehouse import DataWarehouse
+from ITR.interfaces import (
+    ICompanyData,
+    EScope,
+    ETimeFrames,
+    PortfolioCompany,
+    IEIBenchmarkScopes,
+    IProductionBenchmarkScopes,
+)
+from ITR.portfolio_aggregation import PortfolioAggregationMethod
+from ITR.temperature_score import TemperatureScore
+
 import json
 import unittest
 import os
@@ -18,21 +33,6 @@ from dotenv import load_dotenv
 import trino
 import osc_ingest_trino as osc
 from sqlalchemy.engine import create_engine
-
-import ITR
-from ITR import data_dir
-from ITR.portfolio_aggregation import PortfolioAggregationMethod
-from ITR.temperature_score import TemperatureScore
-from ITR.configs import ColumnsConfig, TemperatureScoreConfig
-from ITR.data.data_warehouse import DataWarehouse
-from ITR.interfaces import (
-    ICompanyData,
-    EScope,
-    ETimeFrames,
-    PortfolioCompany,
-    IEIBenchmarkScopes,
-    IProductionBenchmarkScopes,
-)
 
 try:
     from ITR.data.vault_providers import (

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,12 +4,9 @@ import json
 import random
 
 import ITR
-from pint import Quantity
-from pint_pandas import PintType
-from ITR.data.osc_units import EI_Metric, EI_Quantity, asPintSeries
-
-from ITR.interfaces import EScope
+from ITR.data.osc_units import EI_Metric, EI_Quantity, Quantity, asPintSeries
 from ITR.interfaces import (
+    EScope,
     ICompanyData,
     ICompanyEIProjectionsScopes,
     ICompanyEIProjections,


### PR DESCRIPTION
Reordering, reorganization, and pruning of imports so that we always import ITR ahead of pint.  This ensures that pint.Quantity takes from ureg.Quantity and remains consistent.  When the order is no preserved, pint.Quantity might not equal pint.registry.Quantity, breaking things like `isinstance(qty, pint.Quantity).

Also fix up some minor lint.