### PR TITLE
Fix import problems with ITR/utils.py

### DIFF
--- a/src/ITR/__init__.py
+++ b/src/ITR/__init__.py
@@ -8,26 +8,27 @@ import numpy as np
 import pandas as pd
 import pint
 
-from . import data  # noqa F401
+from . import utils  # noqa F401
 from .interfaces import EScope
 
 data_dir = os.path.join(__path__[0], "data", "json")
 
 try:
-    # Even if we have uncertainties available as a module, we don't have the right version of pint
-    if hasattr(pint.compat, "tokenizer"):
-        raise AttributeError
     from uncertainties import UFloat, ufloat
     from uncertainties.unumpy import isnan, nominal_values, std_devs, uarray
 
+    # Even if we have uncertainties available as a module, we don't have the right version of pint
+    if hasattr(pint.compat, "tokenizer"):
+        raise AttributeError
+
     _ufloat_nan = ufloat(np.nan, 0.0)
     pint.pint_eval.tokenizer = pint.pint_eval.uncertainty_tokenizer
-    from .utils import umean
+    from .utils import umean  # noqa F401
 
     HAS_UNCERTAINTIES = True
 except (ImportError, ModuleNotFoundError, AttributeError) as exc:  # noqa F841
     HAS_UNCERTAINTIES = False
-    from statistics import mean
+    from statistics import mean as umean  # noqa F401
 
     from numpy import isnan
 
@@ -44,9 +45,6 @@ except (ImportError, ModuleNotFoundError, AttributeError) as exc:  # noqa F841
 
     def uarray(nom_vals, std_devs):
         return nom_vals
-
-    def umean(unquantified_data):
-        return mean(unquantified_data)
 
 
 def isna(x):

--- a/src/ITR/data/__init__.py
+++ b/src/ITR/data/__init__.py
@@ -111,7 +111,7 @@ pint.Measurement = ureg.Measurement
 pint.Context = ureg.Context
 
 # FIXME: delay loading of pint_pandas until after we've initialized ourselves
-from pint_pandas import PintArray  # noqa E402
+from pint_pandas import PintArray, PintType  # noqa E402
 
 Q_ = ureg.Quantity
 M_ = ureg.Measurement

--- a/src/ITR/data/base_providers.py
+++ b/src/ITR/data/base_providers.py
@@ -7,12 +7,11 @@ from typing import Dict, List, Type
 import numpy as np
 import pandas as pd
 from pint import DimensionalityError
-from pint_pandas import PintType
 
 import ITR
 
 from ..configs import ColumnsConfig, LoggingConfig, ProjectionControls, VariablesConfig
-from ..data import PA_, Q_, ureg
+from ..data import PA_, Q_, PintType, ureg
 from ..data.data_providers import (
     CompanyDataProvider,
     IntensityBenchmarkDataProvider,

--- a/src/ITR/data/data_providers.py
+++ b/src/ITR/data/data_providers.py
@@ -6,7 +6,7 @@ from typing import List
 import pandas as pd
 
 from ..configs import ColumnsConfig  # noqa F401
-from ..data.osc_units import Quantity
+from ..data.osc_units import Quantity_type
 from ..interfaces import (  # noqa F401
     EScope,
     ICompanyData,
@@ -137,8 +137,8 @@ class IntensityBenchmarkDataProvider(ABC):
 
     def __init__(
         self,
-        benchmark_temperature: Quantity["delta_degC"],
-        benchmark_global_budget: Quantity["CO2"],
+        benchmark_temperature: Quantity_type("delta_degC"),
+        benchmark_global_budget: Quantity_type("CO2"),
         is_AFOLU_included: bool,
         **kwargs,
     ):
@@ -164,14 +164,14 @@ class IntensityBenchmarkDataProvider(ABC):
         self._is_AFOLU_included = value
 
     @property
-    def benchmark_temperature(self) -> Quantity["delta_degC"]:
+    def benchmark_temperature(self) -> Quantity_type("delta_degC"):
         """
         :return: assumed temperature for the benchmark. for OECM 1.5C for example
         """
         return self._benchmark_temperature
 
     @property
-    def benchmark_global_budget(self) -> Quantity["CO2"]:
+    def benchmark_global_budget(self) -> Quantity_type("CO2"):
         """
         :return: Benchmark provider assumed global budget. if AFOLU is not included global budget is divided by 0.76
         """

--- a/src/ITR/data/osc_units.py
+++ b/src/ITR/data/osc_units.py
@@ -9,7 +9,6 @@ from typing import Annotated, Any, Dict
 import pandas as pd
 import pint
 from pint import Context, DimensionalityError
-from pint_pandas import PintType
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -24,7 +23,7 @@ from pydantic_core import CoreSchema, core_schema
 
 import ITR
 
-from ..data import PA_, Q_, ureg
+from ..data import PA_, Q_, PintType, ureg
 
 Quantity = ureg.Quantity
 

--- a/src/ITR/data/template.py
+++ b/src/ITR/data/template.py
@@ -7,7 +7,6 @@ from typing import List, Optional, Type
 import numpy as np
 import pandas as pd
 import pint
-from pint_pandas import PintType
 from pydantic import ValidationError
 
 import ITR
@@ -20,7 +19,7 @@ from ..configs import (
     TabsConfig,
     VariablesConfig,
 )
-from ..data import PA_, Q_, ureg
+from ..data import PA_, Q_, PintType, ureg
 from ..data.base_providers import BaseCompanyDataProvider
 from ..data.osc_units import (
     EmissionsMetric,

--- a/src/ITR/data/vault_providers.py
+++ b/src/ITR/data/vault_providers.py
@@ -8,10 +8,9 @@ import osc_ingest_trino as osc
 import pandas as pd
 import sqlalchemy
 from dotenv import load_dotenv
-from pint_pandas import PintArray
 
 from ..configs import ColumnsConfig, LoggingConfig
-from ..data import ureg
+from ..data import PintArray, ureg
 
 # Rather than duplicating a few methods from BaseCompanyDataProvider, we just call them to delegate to them
 from ..data.base_providers import BaseCompanyDataProvider

--- a/src/ITR/interfaces.py
+++ b/src/ITR/interfaces.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
-from pint_pandas import PintType
-from pint_pandas.pint_array import PintSeriesAccessor
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -23,6 +21,7 @@ from pydantic_core import CoreSchema
 import ITR
 
 from .configs import LoggingConfig, ProjectionControls
+from .data import PintType
 from .data.osc_units import (
     PA_,
     Q_,
@@ -378,6 +377,8 @@ class DF_ICompanyEIProjections(BaseModel):
 
     @field_validator("projections")
     def val_projections(cls, v: pd.Series):
+        from pint_pandas.pint_array import PintSeriesAccessor
+
         if isinstance(v.pint, PintSeriesAccessor):
             return v
         raise ValidationError(f"{v} is not composed of a PintArray")

--- a/src/ITR/portfolio_aggregation.py
+++ b/src/ITR/portfolio_aggregation.py
@@ -6,11 +6,11 @@ from typing import Type
 
 import numpy as np
 import pandas as pd
-from pint_pandas import PintType
 
 import ITR
 
 from .configs import ColumnsConfig, LoggingConfig, PortfolioAggregationConfig
+from .data import PintType
 from .data.osc_units import PA_, asPintSeries
 from .interfaces import EScope
 

--- a/src/ITR/utils.py
+++ b/src/ITR/utils.py
@@ -17,7 +17,7 @@ from .configs import (
     TemperatureScoreControls,
 )
 from .data.data_warehouse import DataWarehouse
-from .data.osc_units import Q_, Quantity, asPintSeries
+from .data.osc_units import Q_, Quantity_type, asPintSeries
 from .interfaces import EScope, ETimeFrames, PortfolioCompany, ScoreAggregations
 from .portfolio_aggregation import PortfolioAggregationMethod
 from .temperature_score import TemperatureScore
@@ -152,7 +152,7 @@ def get_data(data_warehouse: DataWarehouse, portfolio: List[PortfolioCompany]) -
 
 def calculate(
     portfolio_data: pd.DataFrame,
-    fallback_score: Quantity["delta_degC"],
+    fallback_score: Quantity_type("delta_degC"),
     aggregation_method: PortfolioAggregationMethod,
     grouping: Optional[List[str]],
     time_frames: List[ETimeFrames],


### PR DESCRIPTION
Rearrange code so that (1) we don't create messy circular dependencies with utils.py, (2) we don't import `pint_pandas` before `ITR`, and (3) we don't let wrongly declared typing information upset our import process.