### PR TITLE
Prune examples and ITR-examples

### DIFF
--- a/examples
+++ b/examples
@@ -1,1 +1,0 @@
-ITR-examples


### PR DESCRIPTION
These are now redundant with the stand-alone ITR-examples repo (IIUC).