### PR TITLE
Refactor code to resolve mypy errors

### DIFF
--- a/.github/workflows/.markdownlint.json
+++ b/.github/workflows/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-  "MD013": {
-    "line_length": 300,
-    "code_block_line_length": 300,
-    "tables": false
-  }
-}

--- a/src/ITR/configs.py
+++ b/src/ITR/configs.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import List
+from typing import Callable, List
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict
 
-from .data.osc_units import EmissionsQuantity, Quantity_type
+from .data.osc_units import EmissionsQuantity, Quantity, delta_degC_Quantity
 
 
 def ITR_median(*args, **kwargs):
@@ -219,16 +219,16 @@ class TemperatureScoreControls(BaseModel):
 
     base_year: int
     target_end_year: int
-    tcre: Quantity_type("delta_degC")
+    tcre: delta_degC_Quantity
     carbon_conversion: EmissionsQuantity
-    scenario_target_temperature: Quantity_type("delta_degC")
+    scenario_target_temperature: delta_degC_Quantity
     target_probability: float
 
     def __getitem__(self, item):
         return getattr(self, item)
 
     @property
-    def tcre_multiplier(self) -> Quantity_type("delta_degC/(t CO2)"):
+    def tcre_multiplier(self) -> Quantity:
         return self.tcre / self.carbon_conversion
 
 

--- a/src/ITR/configs.py
+++ b/src/ITR/configs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Callable, List
+from typing import Callable, List, Optional, Protocol
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict
@@ -211,7 +211,7 @@ class ProjectionControls:
 
     BASE_YEAR: int = 2019
     TARGET_YEAR: int = 2050
-    TREND_CALC_METHOD: Callable[[pd.DataFrame], pd.DataFrame] = ITR_median
+    TREND_CALC_METHOD: Callable[[pd.DataFrame, Optional[str], Optional[bool]], pd.DataFrame] = ITR_median
 
 
 class TemperatureScoreControls(BaseModel):

--- a/src/ITR/data/base_providers.py
+++ b/src/ITR/data/base_providers.py
@@ -278,7 +278,9 @@ class BaseProviderIntensityBenchmark(IntensityBenchmarkDataProvider):
         self._EI_df_t.sort_index(axis=1, inplace=True)
 
     def get_scopes(self) -> List[EScope]:
-        return self._EI_benchmarks.get_level_values("scope").unique().tolist()
+        scopes = [scope for scope in EScope.get_result_scopes()
+                  if getattr(self._EI_benchmarks, scope.name) != ITR.interfaces.empty_IBenchmarks]
+        return scopes
 
     def benchmarks_changed(self, new_projected_ei: IntensityBenchmarkDataProvider) -> bool:
         assert isinstance(new_projected_ei, BaseProviderIntensityBenchmark)

--- a/src/ITR/data/base_providers.py
+++ b/src/ITR/data/base_providers.py
@@ -278,8 +278,11 @@ class BaseProviderIntensityBenchmark(IntensityBenchmarkDataProvider):
         self._EI_df_t.sort_index(axis=1, inplace=True)
 
     def get_scopes(self) -> List[EScope]:
-        scopes = [scope for scope in EScope.get_result_scopes()
-                  if getattr(self._EI_benchmarks, scope.name) != ITR.interfaces.empty_IBenchmarks]
+        scopes = [
+            scope
+            for scope in EScope.get_result_scopes()
+            if getattr(self._EI_benchmarks, scope.name) != ITR.interfaces.empty_IBenchmarks
+        ]
         return scopes
 
     def benchmarks_changed(self, new_projected_ei: IntensityBenchmarkDataProvider) -> bool:

--- a/src/ITR/data/data_providers.py
+++ b/src/ITR/data/data_providers.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional, TypeAlias
 
 import pandas as pd
 
-from ..configs import ColumnsConfig  # noqa F401
-from ..data.osc_units import Quantity_type
+from ..configs import ColumnsConfig, ProjectionControls  # noqa F401
+from ..data.osc_units import EmissionsQuantity, Quantity_type, delta_degC_Quantity
 from ..interfaces import (  # noqa F401
     EScope,
     ICompanyData,
@@ -38,10 +38,24 @@ class CompanyDataProvider(ABC):
         pass
 
     @abstractmethod
-    def get_company_data(self, company_ids: List[str]) -> List[ICompanyData]:
+    def get_projection_controls(self) -> ProjectionControls:
         """
-        Get all relevant data for a list of company ids (ISIN). This method should return a list of ICompanyData
-        instances.
+        Return the ProjectionControls associated with this CompanyDataProvider.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_company_ids(self) -> List[str]:
+        """
+        Return the list of Company IDs of this CompanyDataProvider
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_company_data(self, company_ids: Optional[List[str]] = None) -> List[ICompanyData]:
+        """
+        Get all relevant data for a list of company ids (ISIN), or all company data if `company_ids` is None.
+        This method should return a list of ICompanyData instances.
 
         :param company_ids: A list of company IDs (ISINs)
         :return: A list containing the company data
@@ -87,6 +101,40 @@ class CompanyDataProvider(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def _allocate_emissions(
+        self,
+        new_companies: List[ICompanyData],
+        ei_benchmarks: IntensityBenchmarkDataProvider,
+        projection_controls: ProjectionControls,
+    ):
+        """
+        Use benchmark data from `ei_benchmarks` to allocate sector-level emissions from aggregated emissions.
+        For example, a Utility may supply both Electricity and Gas to customers, reported separately.
+        When we split the company into Electricity and Gas lines of business, we can allocate Scope emissions
+        to the respective lines of business using benchmark averages to guide the allocation.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _validate_projected_trajectories(self, companies: List[ICompanyData], ei_bm: IntensityBenchmarkDataProvider):
+        """
+        Called when benchmark data is first known, or when projection control parameters or benchmark data changes.
+        COMPANY_IDS are a list of companies with historic data that need to be projected.
+        EI_BENCHMARKS are the benchmarks for all sectors, regions, and scopes
+        In previous incarnations of this function, no benchmark data was needed for any reason.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _calculate_target_projections(
+        self, production_bm: ProductionBenchmarkDataProvider, ei_bm: IntensityBenchmarkDataProvider
+    ):
+        """
+        Use benchmark data to calculate target projections
+        """
+        raise NotImplementedError
+
 
 class ProductionBenchmarkDataProvider(ABC):
     """
@@ -103,6 +151,10 @@ class ProductionBenchmarkDataProvider(ABC):
         :param config: A dictionary containing the configuration parameters for this data provider.
         """
         pass
+
+    @abstractmethod
+    def benchmark_changed(self, production_benchmark: ProductionBenchmarkDataProvider) -> bool:
+        raise NotImplementedError
 
     @abstractmethod
     def get_company_projected_production(self, ghg_scope12: pd.DataFrame) -> pd.DataFrame:
@@ -137,8 +189,8 @@ class IntensityBenchmarkDataProvider(ABC):
 
     def __init__(
         self,
-        benchmark_temperature: Quantity_type("delta_degC"),
-        benchmark_global_budget: Quantity_type("CO2"),
+        benchmark_temperature: delta_degC_Quantity,
+        benchmark_global_budget: EmissionsQuantity,
         is_AFOLU_included: bool,
         **kwargs,
     ):
@@ -152,6 +204,18 @@ class IntensityBenchmarkDataProvider(ABC):
         self._is_AFOLU_included = is_AFOLU_included
         self._benchmark_global_budget = benchmark_global_budget
 
+    @abstractmethod
+    def get_scopes(self) -> List[EScope]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def benchmarks_changed(self, ei_benchmarks: IntensityBenchmarkDataProvider) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def prod_centric_changed(self, ei_benchmarks: IntensityBenchmarkDataProvider) -> bool:
+        raise NotImplementedError
+
     @property
     def is_AFOLU_included(self) -> bool:
         """
@@ -164,14 +228,14 @@ class IntensityBenchmarkDataProvider(ABC):
         self._is_AFOLU_included = value
 
     @property
-    def benchmark_temperature(self) -> Quantity_type("delta_degC"):
+    def benchmark_temperature(self) -> delta_degC_Quantity:
         """
         :return: assumed temperature for the benchmark. for OECM 1.5C for example
         """
         return self._benchmark_temperature
 
     @property
-    def benchmark_global_budget(self) -> Quantity_type("CO2"):
+    def benchmark_global_budget(self) -> EmissionsQuantity:
         """
         :return: Benchmark provider assumed global budget. if AFOLU is not included global budget is divided by 0.76
         """
@@ -186,7 +250,7 @@ class IntensityBenchmarkDataProvider(ABC):
         self._benchmark_global_budget = value
 
     @abstractmethod
-    def _get_intensity_benchmarks(self, company_sector_region_info: pd.DataFrame) -> pd.DataFrame:
+    def _get_intensity_benchmarks(self, company_sector_region_info: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         """
         returns a Dataframe with intensity benchmarks per company_id given a region and sector.
         :param company_sector_region_info: DataFrame with at least the following columns :
@@ -202,5 +266,12 @@ class IntensityBenchmarkDataProvider(ABC):
         :param company_sector_region_info: DataFrame with at least the following columns :
         ColumnsConfig.COMPANY_ID, ColumnsConfig.SECTOR and ColumnsConfig.REGION
         :return: A DataFrame with company and intensity benchmarks per calendar year per row
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_production_centric(self) -> bool:
+        """
+        returns True if benchmark is "production_centric" (as defined by OECM)
         """
         raise NotImplementedError

--- a/src/ITR/data/data_providers.py
+++ b/src/ITR/data/data_providers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, TypeAlias
+from typing import List, Optional
 
 import pandas as pd
 

--- a/src/ITR/data/data_warehouse.py
+++ b/src/ITR/data/data_warehouse.py
@@ -50,8 +50,7 @@ class DataWarehouse(ABC):
         company_data: CompanyDataProvider,
         benchmark_projected_production: Optional[ProductionBenchmarkDataProvider],
         benchmarks_projected_ei: Optional[IntensityBenchmarkDataProvider],
-        # FIXME: How do we make the first argument to the Callable `DataWarehouse` not `Any`?
-        estimate_missing_data: Optional[Callable[[Any, ICompanyData], None]] = None,
+        estimate_missing_data: Optional[Callable[["DataWarehouse", ICompanyData], None]] = None,
         column_config: Type[ColumnsConfig] = ColumnsConfig,
     ):
         """

--- a/src/ITR/data/data_warehouse.py
+++ b/src/ITR/data/data_warehouse.py
@@ -201,7 +201,7 @@ class DataWarehouse(ABC):
                     if not ITR.isna(c.ghg_s3):
                         c.ghg_s1s2 = c.ghg_s1s2 + c.ghg_s3
                     c.ghg_s3 = None  # Q_(0.0, c.ghg_s3.u)
-                if c.historic_data:
+                if not c.historic_data.empty():
 
                     def _adjust_historic_data(data, primary_scope_attr, data_adder):
                         if data[primary_scope_attr]:
@@ -232,14 +232,14 @@ class DataWarehouse(ABC):
                         else:
                             setattr(data, primary_scope_attr, data.S3)
 
-                    if c.historic_data.emissions and c.historic_data.emissions.S3:
+                    if c.historic_data.emissions.S3:
                         _adjust_historic_data(c.historic_data.emissions, "S1", IEmissionRealization.add)
                         _adjust_historic_data(c.historic_data.emissions, "S1S2", IEmissionRealization.add)
                         c.historic_data.emissions.S3 = []
-                    if c.historic_data.emissions and c.historic_data.emissions.S1S2S3:
+                    if c.historic_data.emissions.S1S2S3:
                         # assert c.historic_data.emissions.S1S2 == c.historic_data.emissions.S1S2S3
                         c.historic_data.emissions.S1S2S3 = []
-                    if c.historic_data.emissions_intensities and c.historic_data.emissions_intensities.S3:
+                    if c.historic_data.emissions_intensities.S3:
                         _adjust_historic_data(
                             c.historic_data.emissions_intensities,
                             "S1",
@@ -251,10 +251,10 @@ class DataWarehouse(ABC):
                             IEIRealization.add,
                         )
                         c.historic_data.emissions_intensities.S3 = []
-                    if c.historic_data.emissions_intensities and c.historic_data.emissions_intensities.S1S2S3:
+                    if c.historic_data.emissions_intensities.S1S2S3:
                         # assert c.historic_data.emissions_intensities.S1S2 == c.historic_data.emissions_intensities.S1S2S3
                         c.historic_data.emissions_intensities.S1S2S3 = []
-                if c.projected_intensities and c.projected_intensities.S3:
+                if c.projected_intensities.S3:
                     c.projected_intensities._adjust_trajectories("S1")
                     c.projected_intensities._adjust_trajectories("S1S2")
                     c.projected_intensities.S3 = None
@@ -262,7 +262,7 @@ class DataWarehouse(ABC):
                         # assert c.projected_intensities.S1S2.projections == c.projected_intensities.S1S2S3.projections
 
                         c.projected_intensities.S1S2S3 = None
-                if c.projected_targets and c.projected_targets.S3:
+                if c.projected_targets.S3:
                     # For production-centric benchmarks, S3 emissions are counted against S1 (and/or the S1 in S1+S2)
 
                     if c.projected_targets.S1:
@@ -320,7 +320,7 @@ class DataWarehouse(ABC):
                             f"S1+S2 targets not aligned with S3 targets for company with ID {c.company_id}; ignoring S3 data"
                         )
                     c.projected_targets.S3 = None
-                if c.projected_targets and c.projected_targets.S1S2S3:
+                if c.projected_targets.S1S2S3:
                     # assert c.projected_targets.S1S2 == c.projected_targets.S1S2S3
                     c.projected_targets.S1S2S3 = None
         elif new_prod_centric and self.orig_historic_data != {}:

--- a/src/ITR/data/data_warehouse.py
+++ b/src/ITR/data/data_warehouse.py
@@ -1,7 +1,7 @@
 import logging
 import warnings  # needed until apply behaves better with Pint quantities in arrays
 from abc import ABC
-from typing import List, Type
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import numpy as np
 import pandas as pd
@@ -17,7 +17,12 @@ from ..data.data_providers import (
     IntensityBenchmarkDataProvider,
     ProductionBenchmarkDataProvider,
 )
-from ..data.osc_units import EmissionsQuantity, Quantity_type, asPintDataFrame
+from ..data.osc_units import (
+    EmissionsQuantity,
+    Quantity_type,
+    asPintDataFrame,
+    delta_degC_Quantity,
+)
 from ..interfaces import (
     DF_ICompanyEIProjections,
     EScope,
@@ -43,9 +48,10 @@ class DataWarehouse(ABC):
     def __init__(
         self,
         company_data: CompanyDataProvider,
-        benchmark_projected_production: ProductionBenchmarkDataProvider,
-        benchmarks_projected_ei: IntensityBenchmarkDataProvider,
-        estimate_missing_data=None,
+        benchmark_projected_production: Optional[ProductionBenchmarkDataProvider],
+        benchmarks_projected_ei: Optional[IntensityBenchmarkDataProvider],
+        # FIXME: How do we make the first argument to the Callable `DataWarehouse` not `Any`?
+        estimate_missing_data: Optional[Callable[[Any, ICompanyData], None]] = None,
         column_config: Type[ColumnsConfig] = ColumnsConfig,
     ):
         """
@@ -64,8 +70,8 @@ class DataWarehouse(ABC):
         self.company_data = company_data
         self.estimate_missing_data = estimate_missing_data
         # Place to stash historic data before doing PC-conversion so it can be retreived when switching to non-PC benchmarks
-        self.orig_historic_data = {}
-        self.company_scope = {}
+        self.orig_historic_data: Dict[str, Any] = {}
+        self.company_scope: Dict[str, EScope] = {}
 
         # Production benchmark data is needed to project trajectories
         # Trajectories + Emissions Intensities benchmark data are needed to estimate missing S3 data
@@ -125,224 +131,72 @@ class DataWarehouse(ABC):
 
     def update_benchmarks(
         self,
-        benchmark_projected_production: ProductionBenchmarkDataProvider,
-        benchmarks_projected_ei: IntensityBenchmarkDataProvider,
+        benchmark_projected_production: Optional[ProductionBenchmarkDataProvider],
+        benchmarks_projected_ei: Optional[IntensityBenchmarkDataProvider],
     ):
         """
         Update the benchmark data used in this instance of the DataWarehouse.  If there is no change, do nothing.
         """
         new_production_bm = new_ei_bm = new_prod_centric = False
-        assert benchmark_projected_production is not None
-        if (
-            self.benchmark_projected_production is None
-            or self.benchmark_projected_production._productions_benchmarks
-            != benchmark_projected_production._productions_benchmarks
+        if self.benchmark_projected_production is None or self.benchmark_projected_production.benchmark_changed(
+            benchmark_projected_production
         ):
-            self.benchmark_projected_production = benchmark_projected_production
+            self.benchmark_projected_production = benchmark_projected_production  # type: ignore
             new_production_bm = True
-        assert benchmarks_projected_ei is not None
-        if (
-            self.benchmarks_projected_ei is None
-            or self.benchmarks_projected_ei._EI_benchmarks != benchmarks_projected_ei._EI_benchmarks
-        ):
-            prev_prod_centric = next_prod_centric = False
-            if self.benchmarks_projected_ei is not None and getattr(
-                self.benchmarks_projected_ei._EI_benchmarks, "S1S2", None
-            ):
-                prev_prod_centric = self.benchmarks_projected_ei._EI_benchmarks["S1S2"].production_centric
-            if getattr(benchmarks_projected_ei._EI_benchmarks, "S1S2", None):
-                next_prod_centric = benchmarks_projected_ei._EI_benchmarks["S1S2"].production_centric
-            new_prod_centric = prev_prod_centric != next_prod_centric
+
+        if self.benchmarks_projected_ei is None:
+            self.benchmarks_projected_ei = benchmarks_projected_ei  # type: ignore
+            new_ei_bm = True
+        elif self.benchmarks_projected_ei.benchmarks_changed(benchmarks_projected_ei):
+            new_prod_centric = self.benchmarks_projected_ei.prod_centric_changed(benchmarks_projected_ei)
             self.benchmarks_projected_ei = benchmarks_projected_ei
             new_ei_bm = True
+        assert self.benchmarks_projected_ei is not None
 
         # Production benchmark data is needed to project trajectories
         # Trajectories + Emissions Intensities benchmark data are needed to estimate missing S3 data
         # Target projections rely both on Production benchmark data and S3 estimated data
         # Production-centric benchmarks shift S3 data after trajectory and targets have been projected
         if new_production_bm:
+            cd_pc = self.company_data.get_projection_controls()
             logger.info(
-                f"new_production_bm calculating trajectories for {len(self.company_data._companies)} companies (times {len(EScope.get_scopes())} scopes times {self.company_data.projection_controls.TARGET_YEAR-self.company_data.projection_controls.BASE_YEAR} years)"
+                f"new_production_bm calculating trajectories for {len(self.company_data.get_company_data())}"
+                f"companies (times {len(EScope.get_scopes())} scopes times "
+                f"{cd_pc.TARGET_YEAR-cd_pc.BASE_YEAR} years)"
             )
             self.company_data._validate_projected_trajectories(
-                self.company_data._companies, self.benchmarks_projected_ei._EI_df_t
+                self.company_data.get_company_data(), self.benchmarks_projected_ei
             )
 
-        if new_ei_bm and (new_companies := [c for c in self.company_data._companies if "+" in c.company_id]):
-            logger.info("Allocating emissions to align with benchmark data")
-            bm_prod_df = benchmark_projected_production._prod_df
-            bm_ei_df_t = benchmarks_projected_ei._EI_df_t
-            bm_sectors = bm_ei_df_t.columns.get_level_values("sector").unique().to_list()
-            base_year = self.company_data.projection_controls.BASE_YEAR
-
-            from collections import defaultdict
-
-            sectors_dict = defaultdict(list)
-            region_dict = {}
-            historic_dict = {}
-
-            for c in new_companies:
-                orig_id, sector = c.company_id.split("+")
-                if sector in bm_sectors:
-                    sectors_dict[orig_id].append(sector)
-                else:
-                    logger.error(f"No benchmark sector data for {orig_id}: sector = {sector}")
-                    continue
-                if (sector, c.region) in bm_ei_df_t.columns:
-                    region_dict[orig_id] = c.region
-                elif (sector, "Global") in bm_ei_df_t.columns:
-                    region_dict[orig_id] = "Global"
-                else:
-                    logger.error(f"No benchmark region data for {orig_id}: sector = {sector}; region = {region}")
-                    continue
-
-                # Though we mutate below, it's our own unique copy of c.historic_data we are mutating, so OK
-                historic_dict[c.company_id] = c.historic_data
-
-            for orig_id, sectors in sectors_dict.items():
-                region = region_dict[orig_id]
-                sector_ei = [
-                    (
-                        sector,
-                        scope,
-                        # bm_prod_df.loc[(sector, region, EScope.AnyScope)][base_year] is '1.0 dimensionless'
-                        bm_ei_df_t.loc[:, (sector, region, scope)][base_year],
-                    )
-                    for scope in EScope.get_result_scopes()
-                    # This only saves us from having data about sectorized alignments we might not need.  It doesn't affect the emissions being allocated (or not).
-                    if (c.company_id, scope.name) in self.company_data._bm_allocation_index
-                    for sector in sectors
-                    if (sector, region, scope) in bm_ei_df_t.columns
-                    and historic_dict["+".join([orig_id, sector])].emissions[scope.name]
-                ]
-                sector_ei_df = pd.DataFrame(sector_ei, columns=["sector", "scope", "ei"]).set_index(["sector"])
-                sector_prod_df = pd.DataFrame(
-                    [
-                        (sector, prod.value)
-                        for sector in sectors
-                        for prod in historic_dict["+".join([orig_id, sector])].productions
-                        # FIXME: if we don't have proudction values for BASE_YEAR, this fails!  See 'US2333311072+Gas Utilities'
-                        if prod.year == base_year
-                    ],
-                    columns=["sector", "prod"],
-                ).set_index("sector")
-                sector_em_df = (
-                    sector_ei_df.join(sector_prod_df)
-                    .assign(em=lambda x: x["ei"] * x["prod"])
-                    .set_index("scope", append=True)
-                    .drop(columns=["ei", "prod"])
-                )
-                # Only now can we drop whatever is not in self.company_data._bm_allocation_index from sector_em_df
-                if self.company_data._bm_allocation_index.empty:
-                    # No allocations to make for any companies
-                    continue
-                to_allocate_idx = self.company_data._bm_allocation_index[
-                    self.company_data._bm_allocation_index.map(lambda x: x[0].startswith(orig_id))
-                ].map(lambda x: (x[0].split("+")[1], EScope[x[1]]))
-                if to_allocate_idx.empty:
-                    logger.info(f"Already allocated emissions for {orig_id} across {sectors}")
-                    continue
-                # FIXME: to_allocate_idx is missing S1S2S3 for US2091151041
-                to_allocate_idx.names = ["sector", "scope"]
-                try:
-                    sector_em_df = sector_em_df.loc[sector_em_df.index.intersection(to_allocate_idx)].astype(
-                        "pint[Mt CO2e]"
-                    )
-                except DimensionalityError:
-                    # breakpoint()
-                    assert False
-                em_tot = sector_em_df.groupby("scope")["em"].sum()
-                # The alignment calculation: Company Scope-Sector emissions = Total Company Scope emissions * (BM Scope Sector / SUM(All Scope Sectors of Company))
-                aligned_em = [
-                    (
-                        sector,
-                        [
-                            (
-                                scope,
-                                list(
-                                    map(
-                                        lambda em: (
-                                            em[0],
-                                            em[1]
-                                            * sector_em_df.loc[(sector, scope)].squeeze()
-                                            / em_tot.loc[scope].squeeze(),
-                                        ),
-                                        [
-                                            (em.year, em.value)
-                                            for em in historic_dict["+".join([orig_id, sector])].emissions[scope.name]
-                                        ],
-                                    )
-                                ),
-                            )
-                            for scope in em_tot.index
-                            if em_tot.loc[scope].squeeze().m != 0.0
-                        ],
-                    )
-                    for sector in sectors
-                ]
-
-                # Having done all scopes and sectors for this company above, replace historic Em and EI data below
-                for sector_aligned in aligned_em:
-                    sector, scopes = sector_aligned
-                    historic_sector = historic_dict["+".join([orig_id, sector])]
-                    # print(f"Historic {sector} initially\n{historic_sector.emissions}")
-                    for scope_tuple in scopes:
-                        scope, em_list = scope_tuple
-                        setattr(
-                            historic_sector.emissions,
-                            scope.name,
-                            list(
-                                map(
-                                    lambda em: IEmissionRealization(year=em[0], value=em[1].to("Mt CO2e")),
-                                    em_list,
-                                )
-                            ),
-                        )
-                        prod_list = historic_sector.productions
-                        ei_list = list(
-                            map(
-                                lambda em_p: IEIRealization(
-                                    year=em_p[0].year,
-                                    value=Q_(
-                                        np.nan,
-                                        f"({em_p[0].value.u}) / ({em_p[1].value.u})",
-                                    )
-                                    if em_p[1].value.m == 0.0
-                                    else em_p[0].value / em_p[1].value,
-                                ),
-                                zip(historic_sector.emissions[scope.name], prod_list),
-                            )
-                        )
-                        setattr(historic_sector.emissions_intensities, scope.name, ei_list)
-                    # print(f"Historic {sector} adjusted\n{historic_dict['+'.join([orig_id, sector])].emissions}")
-            logger.info("Sector alignment complete")
+        if new_ei_bm and (new_companies := [c for c in self.company_data.get_company_data() if "+" in c.company_id]):
+            self.company_data._allocate_emissions(
+                new_companies, self.benchmarks_projected_ei, self.company_data.get_projection_controls()
+            )
 
         # If we are missing S3 (or other) data, fill in before projecting targets
         if new_ei_bm and self.estimate_missing_data is not None:
             logger.info(f"estimating missing data")
-            for c in self.company_data._companies:
+            for c in self.company_data.get_company_data():
                 self.estimate_missing_data(self, c)
 
         # Changes to production benchmark requires re-calculating targets (which are production-dependent)
         if new_production_bm:
+            cd_pc = self.company_data.get_projection_controls()
             logger.info(
-                f"projecting targets for {len(self.company_data._companies)} companies (times {len(EScope.get_scopes())} scopes times {self.company_data.projection_controls.TARGET_YEAR-self.company_data.projection_controls.BASE_YEAR} years)"
+                f"projecting targets for {len(self.company_data.get_company_data())} companies "
+                f"(times {len(EScope.get_scopes())} scopes times {cd_pc.TARGET_YEAR-cd_pc.BASE_YEAR} years)"
             )
             self.company_data._calculate_target_projections(benchmark_projected_production, benchmarks_projected_ei)
 
         # If our benchmark is production-centric, migrate S3 data (including estimated S3 data) into S1S2
         # If we shift before we project, then S3 targets will not be projected correctly.
-        if (
-            new_ei_bm
-            and getattr(benchmarks_projected_ei._EI_benchmarks, "S1S2", None)
-            and benchmarks_projected_ei._EI_benchmarks["S1S2"].production_centric
-        ):
+        if new_ei_bm and benchmarks_projected_ei.is_production_centric():
             logger.info(f"Shifting S3 emissions data into S1 according to Production-Centric benchmark rules")
             if self.orig_historic_data != {}:
                 self._restore_historic_data()
             else:
                 self._preserve_historic_data()
-            for c in self.company_data._companies:
+            for c in self.company_data.get_company_data():
                 if c.ghg_s3:
                     # For Production-centric and energy-only data (except for Cement), convert all S3 numbers to S1 numbers
                     if not ITR.isna(c.ghg_s3):
@@ -402,74 +256,27 @@ class DataWarehouse(ABC):
                         # assert c.historic_data.emissions_intensities.S1S2 == c.historic_data.emissions_intensities.S1S2S3
                         c.historic_data.emissions_intensities.S1S2S3 = []
                 if c.projected_intensities and c.projected_intensities.S3:
-
-                    def _adjust_trajectories(trajectories, primary_scope_attr):
-                        if not trajectories[primary_scope_attr]:
-                            setattr(trajectories, primary_scope_attr, trajectories.S3)
-                        else:
-                            if isinstance(trajectories.S3.projections, pd.Series):
-                                trajectories[primary_scope_attr].projections = trajectories[
-                                    primary_scope_attr
-                                ].projections.add(trajectories.S3.projections)
-                            else:
-                                # Should not be reached as we are using DF_ICompanyEIProjections consistently now
-                                # breakpoint()
-                                assert False
-                                trajectories[primary_scope_attr].projections = list(
-                                    map(
-                                        ICompanyEIProjection.add,
-                                        trajectories[primary_scope_attr].projections,
-                                        trajectories.S3.projections,
-                                    )
-                                )
-
-                    _adjust_trajectories(c.projected_intensities, "S1")
-                    _adjust_trajectories(c.projected_intensities, "S1S2")
+                    c.projected_intensities._adjust_trajectories("S1")
+                    c.projected_intensities._adjust_trajectories("S1S2")
                     c.projected_intensities.S3 = None
                     if c.projected_intensities.S1S2S3:
                         # assert c.projected_intensities.S1S2.projections == c.projected_intensities.S1S2S3.projections
+
                         c.projected_intensities.S1S2S3 = None
                 if c.projected_targets and c.projected_targets.S3:
                     # For production-centric benchmarks, S3 emissions are counted against S1 (and/or the S1 in S1+S2)
-                    def _align_and_sum_projected_targets(targets, primary_scope_attr):
-                        if targets[primary_scope_attr] is None:
-                            raise AttributeError
-                        primary_projections = targets[primary_scope_attr].projections
-                        s3_projections = targets.S3.projections
-                        if isinstance(s3_projections, pd.Series):
-                            targets[primary_scope_attr].projections = (
-                                # We should convert S3 data from benchmark-type to disclosed-type earlier in the chain
-                                primary_projections
-                                + s3_projections.astype(primary_projections.dtype)
-                            )
-                        else:
-                            # Should not be reached as we are using DF_ICompanyEIProjections consistently now
-                            # breakpoint()
-                            assert False
-                            if primary_projections[0].year < s3_projections[0].year:
-                                while primary_projections[0].year < s3_projections[0].year:
-                                    primary_projections = primary_projections[1:]
-                            elif primary_projections[0].year > s3_projections[0].year:
-                                while primary_projections[0].year > s3_projections[0].year:
-                                    s3_projections = s3_projections[1:]
-                            targets[primary_scope_attr].projections = list(
-                                map(
-                                    ICompanyEIProjection.add,
-                                    primary_projections,
-                                    s3_projections,
-                                )
-                            )
 
                     if c.projected_targets.S1:
-                        _align_and_sum_projected_targets(c.projected_targets, "S1")
+                        c.projected_targets._align_and_sum_projected_targets("S1")
                     try:
                         # S3 projected targets may have been synthesized from a netzero S1S2S3 target and might need to be date-aligned with S1S2
-                        _align_and_sum_projected_targets(c.projected_targets, "S1S2")
+                        c.projected_targets._align_and_sum_projected_targets("S1S2")
                     except AttributeError:
-                        if c.projected_targets.S2:
+                        if c.projected_targets.S2 is not None:
                             logger.warning(
                                 f"Scope 1+2 target projections should have been created for {c.company_id}; repairing"
                             )
+                            assert c.projected_targets.S1 is not None
                             if isinstance(c.projected_targets.S1.projections, pd.Series) and isinstance(
                                 c.projected_targets.S2.projections, pd.Series
                             ):
@@ -492,6 +299,7 @@ class DataWarehouse(ABC):
                             logger.warning(
                                 f"Scope 2 target projections missing from company with ID {c.company_id}; treating as zero"
                             )
+                            assert c.projected_targets.S1 is not None
                             if isinstance(c.projected_targets.S1.projections, pd.Series):
                                 c.projected_targets.S1S2 = DF_ICompanyEIProjections(
                                     ei_metric=c.projected_targets.S1.ei_metric,
@@ -503,7 +311,7 @@ class DataWarehouse(ABC):
                                     projections=c.projected_targets.S1.projections,
                                 )
                         if c.projected_targets.S3:
-                            _align_and_sum_projected_targets(c.projected_targets, "S1S2")
+                            c.projected_targets._align_and_sum_projected_targets("S1S2")
                         else:
                             logger.warning(
                                 f"Scope 3 target projections missing from company with ID {c.company_id}; treating as zero"
@@ -523,18 +331,19 @@ class DataWarehouse(ABC):
         # Set scope information based on what company reports and what benchmark requres
         # benchmarks_projected_ei._EI_df_t makes life a bit easier...
         missing_company_scopes = []
-        for c in self.company_data._companies:
+        ei_df_t = benchmarks_projected_ei._get_intensity_benchmarks()
+        for c in self.company_data.get_company_data():
             region = c.region
             try:
-                bm_company_sector_region = benchmarks_projected_ei._EI_df_t[(c.sector, region)]
+                bm_company_sector_region = ei_df_t[(c.sector, region)]
             except KeyError:
                 try:
                     region = "Global"
-                    bm_company_sector_region = benchmarks_projected_ei._EI_df_t[(c.sector, region)]
+                    bm_company_sector_region = ei_df_t[(c.sector, region)]
                 except KeyError:
                     missing_company_scopes.append(c.company_id)
                     continue
-            scopes = benchmarks_projected_ei._EI_df_t[(c.sector, region)].columns.tolist()
+            scopes = ei_df_t[(c.sector, region)].columns.tolist()
             if len(scopes) == 1:
                 self.company_scope[c.company_id] = scopes[0]
                 continue
@@ -561,18 +370,17 @@ class DataWarehouse(ABC):
         )
         for company in self.company_data._companies:
             company.projected_intensities = None
-        self.company_data._validate_projected_trajectories(
-            self.company_data._companies, self.benchmarks_projected_ei._EI_df_t
-        )
+        self.company_data._validate_projected_trajectories(self.company_data._companies, self.benchmarks_projected_ei)
 
-    def estimate_missing_s3_data(self, company: ICompanyData) -> None:
+    def estimate_missing_s3_data(self, company: ICompanyData):
         # We need benchmark data to estimate S3 from projected_intensities (which go back in time to BASE_YEAR).
         # We don't need to estimate further back than that, as we don't rewrite values stored in historic_data.
         # Benchmarks that don't have S3 emissions (such as TPI for Electricity Utilities) take this early return
+        assert company.projected_intensities is not None
         if (
             company.projected_intensities.S3
             or not self.benchmarks_projected_ei
-            or not self.benchmarks_projected_ei._EI_benchmarks.S3
+            or EScope.S3 not in self.benchmarks_projected_ei.get_scopes()
         ):
             return
 
@@ -580,9 +388,10 @@ class DataWarehouse(ABC):
         # It won't solve S3 = S1S2S3 - S1S2 (which should be done elsewhere)
         sector = company.sector
         region = company.region
-        if (sector, region) in self.benchmarks_projected_ei._EI_df_t.columns:
+        ei_df_t = self.benchmarks_projected_ei._get_intensity_benchmarks()
+        if (sector, region) in ei_df_t.columns:
             pass
-        elif (sector, "Global") in self.benchmarks_projected_ei._EI_df_t.columns:
+        elif (sector, "Global") in ei_df_t.columns:
             region = "Global"
         else:
             return
@@ -590,7 +399,7 @@ class DataWarehouse(ABC):
             sector,
             region,
             EScope.S3,
-        ) not in self.benchmarks_projected_ei._EI_df_t.columns:
+        ) not in ei_df_t.columns:
             if sector == "Construction Buildings":
                 # Construction Buildings don't have an S3 scope defined
                 return
@@ -598,14 +407,14 @@ class DataWarehouse(ABC):
                 # Some benchmarks don't include S3 for all sectors; so nothing to estimate
                 return
         else:
-            bm_ei_s3 = self.benchmarks_projected_ei._EI_df_t[(sector, region, EScope.S3)]
+            bm_ei_s3 = ei_df_t[(sector, region, EScope.S3)]
         if (
             sector,
             region,
             EScope.S1S2,
-        ) in self.benchmarks_projected_ei._EI_df_t.columns:
+        ) in ei_df_t.columns:
             # If we have only S1S2S3 emissions, we can "allocate" them according to the benchmark's allocation
-            bm_ei_s1s2 = self.benchmarks_projected_ei._EI_df_t[(sector, region, EScope.S1S2)]
+            bm_ei_s1s2 = ei_df_t[(sector, region, EScope.S1S2)]
         else:
             bm_ei_s1s2 = None
 
@@ -637,7 +446,7 @@ class DataWarehouse(ABC):
             )
             company.projected_intensities.S3 = DF_ICompanyEIProjections(ei_metric=ei_metric, projections=s3_projections)
             company.ghg_s1s2 = (
-                s1s2_projections[self.company_data.projection_controls.BASE_YEAR] * company.base_year_production
+                s1s2_projections[self.company_data.get_projection_controls().BASE_YEAR] * company.base_year_production
             ).to("t CO2e")
         else:
             # Penalize non-disclosure by assuming 2x aligned S3 emissions.  That's still likely undercounting, because
@@ -664,7 +473,7 @@ class DataWarehouse(ABC):
                     )
 
         company.ghg_s3 = (
-            s3_projections[self.company_data.projection_controls.BASE_YEAR] * company.base_year_production
+            s3_projections[self.company_data.get_projection_controls().BASE_YEAR] * company.base_year_production
         ).to("t CO2e")
         logger.info(f"Added S3 estimates for {company.company_id} (sector = {sector}, region = {region})")
 
@@ -678,7 +487,7 @@ class DataWarehouse(ABC):
         base_year: int,
         target_year: int,
         budgeted_ei: pd.DataFrame,
-        benchmark_temperature: Quantity_type("delta_degC"),
+        benchmark_temperature: delta_degC_Quantity,
         global_budget: EmissionsQuantity,
     ) -> pd.DataFrame:
         # trajectories are projected from historic data and we are careful to fill all gaps between historic and projections
@@ -747,7 +556,7 @@ class DataWarehouse(ABC):
         if na_company_mask.any():
             # Happens when the benchmark doesn't cover the company's supplied scopes at all
             logger.warning(
-                f"Dropping companies with no scope data: {df_company_scope[na_company_mask].index.get_level_values(level='company_id').to_list()}"
+                f"Dropping companies with no scope data: {df_company_data[na_company_mask].index.get_level_values(level='company_id').to_list()}"
             )
             df_company_data = df_company_data[~na_company_mask]
         df_company_data[ColumnsConfig.BENCHMARK_GLOBAL_BUDGET] = pd.Series(
@@ -778,22 +587,25 @@ class DataWarehouse(ABC):
             valid_company_ids
         )
 
+        cd_pc = self.company_data.get_projection_controls()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             # See https://github.com/hgrecco/pint-pandas/issues/128
+            assert self.benchmark_projected_production is not None
             projected_production = self.benchmark_projected_production.get_company_projected_production(
                 company_info_at_base_year
             )
-            target_year_loc = projected_production.columns.get_loc(self.company_data.projection_controls.TARGET_YEAR)
+            target_year_loc = projected_production.columns.get_loc(cd_pc.TARGET_YEAR)
             projected_production = projected_production.iloc[:, 0 : target_year_loc + 1]
 
+        assert self.benchmarks_projected_ei is not None
         df_company_data = self._process_company_data(
             df_company_data,
             projected_production=projected_production,
             projected_trajectories=self.company_data.get_company_projected_trajectories(valid_company_ids),
             projected_targets=self.company_data.get_company_projected_targets(valid_company_ids),
-            base_year=self.company_data.projection_controls.BASE_YEAR,
-            target_year=self.company_data.projection_controls.TARGET_YEAR,
+            base_year=cd_pc.BASE_YEAR,
+            target_year=cd_pc.TARGET_YEAR,
             budgeted_ei=self.benchmarks_projected_ei.get_SDA_intensity_benchmarks(company_info_at_base_year),
             benchmark_temperature=self.benchmarks_projected_ei.benchmark_temperature,
             global_budget=self.benchmarks_projected_ei.benchmark_global_budget,
@@ -893,7 +705,7 @@ class DataWarehouse(ABC):
         df_budget: pd.DataFrame,
         base_year: int,
         target_year: int,
-        budget_year: int = None,
+        budget_year: Optional[int],
     ) -> pd.Series:
         """
         :param df_subject: DataFrame of cumulative emissions values over time

--- a/src/ITR/data/excel.py
+++ b/src/ITR/data/excel.py
@@ -1,6 +1,6 @@
 import logging
 import warnings  # needed until apply behaves better with Pint quantities in arrays
-from typing import List, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 import numpy as np
 import pandas as pd
@@ -24,6 +24,7 @@ from ..data.osc_units import (
     EI_Quantity,
     EmissionsQuantity,
     Quantity_type,
+    delta_degC_Quantity,
 )
 from ..interfaces import (
     EScope,
@@ -122,7 +123,7 @@ def convert_benchmarks_ei_excel_to_model(
         .reset_index(drop=True)
         .set_index([column_name_sector, column_name_region, "benchmark_metric", "scope"])
     )
-    bm_dict = {scope_name: [] for scope_name in EScope.get_scopes()}
+    bm_dict: Dict[str, Any] = {scope_name: [] for scope_name in EScope.get_scopes()}
     bm_dict["benchmark_temperature"] = benchmark_temperature
     bm_dict["benchmark_global_budget"] = benchmark_global_budget
     bm_dict["is_AFOLU_included"] = is_AFOLU_included
@@ -178,7 +179,7 @@ class ExcelProviderIntensityBenchmark(BaseProviderIntensityBenchmark):
     def __init__(
         self,
         excel_path: str,
-        benchmark_temperature: Quantity_type("delta_degC"),
+        benchmark_temperature: delta_degC_Quantity,
         benchmark_global_budget: EmissionsQuantity,
         is_AFOLU_included: bool,
         column_config: Type[ColumnsConfig] = ColumnsConfig,
@@ -214,11 +215,11 @@ class ExcelProviderCompany(BaseCompanyDataProvider):
         self,
         excel_path: str,
         column_config: Type[ColumnsConfig] = ColumnsConfig,
-        projection_controls: Type[ProjectionControls] = ProjectionControls,
+        projection_controls: ProjectionControls = ProjectionControls(),
     ):
         self.projection_controls = projection_controls
         self._companies = self._convert_from_excel_data(excel_path)
-        self.historic_years = None
+        self.historic_years: List[int] = []
         super().__init__(self._companies, column_config, projection_controls)
 
     def _check_company_data(self, company_tabs: dict) -> None:
@@ -308,7 +309,7 @@ class ExcelProviderCompany(BaseCompanyDataProvider):
 
         return self._company_df_to_model(df_fundamentals, df_targets, df_ei, df_historic)
 
-    def _convert_series_to_projections(self, projections: pd.Series, ProjectionType: BaseModel) -> [IProjection]:
+    def _convert_series_to_projections(self, projections: pd.Series, ProjectionType: BaseModel) -> List[IProjection]:
         """
         Converts a Pandas Series to a list of IProjection
         :param projections: Pandas Series with years as indices

--- a/src/ITR/data/excel.py
+++ b/src/ITR/data/excel.py
@@ -523,7 +523,7 @@ class ExcelProviderCompany(BaseCompanyDataProvider):
         :return: A list containing historic productions, or None if no data are provided
         """
         if productions.empty:
-            return None
+            return []
         return [
             IProductionRealization(year=year, value=ProductionQuantity(productions[year].squeeze()))
             for year in self.historic_years

--- a/src/ITR/data/osc_units.py
+++ b/src/ITR/data/osc_units.py
@@ -4,7 +4,7 @@ This module handles initialization of pint functionality
 
 import re
 from dataclasses import dataclass
-from typing import Annotated, Any, Dict, List, TypeAlias, Union
+from typing import Annotated, Any, Dict, List, Union
 
 import pandas as pd
 import pint
@@ -20,6 +20,7 @@ from pydantic import (
 from pydantic.functional_validators import AfterValidator, BeforeValidator
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
+from typing_extensions import TypeAlias
 
 import ITR
 

--- a/src/ITR/data/osc_units.py
+++ b/src/ITR/data/osc_units.py
@@ -4,7 +4,7 @@ This module handles initialization of pint functionality
 
 import re
 from dataclasses import dataclass
-from typing import Annotated, Any, Dict
+from typing import Annotated, Any, Dict, List, TypeAlias, Union
 
 import pandas as pd
 import pint
@@ -25,7 +25,7 @@ import ITR
 
 from ..data import PA_, Q_, PintType, ureg
 
-Quantity = ureg.Quantity
+Quantity: TypeAlias = ureg.Quantity
 
 ureg.define("CO2e = CO2 = CO2eq = CO2_eq")
 # openscm_units does this for all gas species...we just have to keep up.
@@ -144,7 +144,7 @@ ureg.enable_contexts("ngas", "coal")
 
 
 # from https://github.com/hgrecco/pint/discussions/1697
-def direct_conversions(ureg, unit) -> [str]:
+def direct_conversions(ureg, unit) -> List[str]:
     """
     Return a LIST of unit names that Pint can convert implicitly from/to UNIT.
     This does not include the list of additional unit names that can be explicitly
@@ -402,7 +402,7 @@ def check_BenchmarkMetric(units: str) -> str:
 BenchmarkMetric = Annotated[str, AfterValidator(check_BenchmarkMetric)]
 
 
-def to_Quantity(quantity: Any) -> Quantity:
+def to_Quantity(quantity: Union[Quantity, str]) -> Quantity:
     if isinstance(quantity, str):
         try:
             v, u = quantity.split(" ", 1)
@@ -412,7 +412,7 @@ def to_Quantity(quantity: Any) -> Quantity:
                 quantity = Q_(int(v), u)
         except ValueError:
             return ureg(quantity)
-    elif not isinstance(quantity, Quantity):
+    elif not isinstance(quantity, Quantity):  # type: ignore
         raise ValueError(f"{quantity} is not a Quantity")
     return quantity
 
@@ -518,6 +518,44 @@ def check_MonetaryQuantity(quantity: Quantity) -> Quantity:
 MonetaryQuantity = Annotated[Quantity, BeforeValidator(to_Quantity), AfterValidator(check_MonetaryQuantity)]
 
 
+def check_delta_degC_Quantity(quantity: Quantity) -> Quantity:
+    try:
+        if quantity.is_compatible_with("delta_degC"):
+            return quantity
+    except RecursionError:
+        # breakpoint()
+        raise
+    raise DimensionalityError(
+        quantity,
+        "delta_degC",
+        dim1="",
+        dim2="",
+        extra_msg=f"Dimensionality must be compatible with delta_degC",
+    )
+
+
+delta_degC_Quantity = Annotated[Quantity, BeforeValidator(to_Quantity), AfterValidator(check_delta_degC_Quantity)]
+
+
+def check_percent_Quantity(quantity: Quantity) -> Quantity:
+    try:
+        if quantity.dimensionless:
+            return quantity.to("percent")
+    except RecursionError:
+        # breakpoint()
+        raise
+    raise DimensionalityError(
+        quantity,
+        "percent",
+        dim1="",
+        dim2="",
+        extra_msg=f"Quantity must be dimensionless",
+    )
+
+
+percent_Quantity = Annotated[Quantity, BeforeValidator(to_Quantity), AfterValidator(check_percent_Quantity)]
+
+
 def Quantity_type(units: str) -> type:
     """A method for making a pydantic compliant Pint quantity field type."""
 
@@ -529,7 +567,6 @@ def Quantity_type(units: str) -> type:
     def __get_pydantic_core_schema__(source_type: Any) -> CoreSchema:
         return core_schema.general_plain_validator_function(lambda value, info: validate(value, units, info))
 
-    @classmethod
     def __get_pydantic_json_schema__(cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
         json_schema = handler(core_schema)
         json_schema = handler.resolve_ref_schema(json_schema)
@@ -575,7 +612,7 @@ def asPintSeries(series: pd.Series, name=None, errors="ignore", inplace=False) -
             raise ValueError("Series not dtype('O')")
     # NA_VALUEs are true NaNs, missing units
     na_values = ITR.isna(series)
-    units = series[~na_values].map(lambda x: x.u if isinstance(x, Quantity) else None)
+    units = series[~na_values].map(lambda x: x.u if isinstance(x, Quantity) else None)  # type: ignore
     unit_first_idx = units.first_valid_index()
     if unit_first_idx is None:
         if errors != "ignore":

--- a/src/ITR/data/template.py
+++ b/src/ITR/data/template.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import re
 import warnings  # needed until apply behaves better with Pint quantities in arrays
-from typing import List, Optional, Type
+from typing import Dict, List, Optional, Type
 
 import numpy as np
 import pandas as pd
@@ -248,7 +248,7 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
         self,
         excel_path: str,
         column_config: Type[ColumnsConfig] = ColumnsConfig,
-        projection_controls: Type[ProjectionControls] = ProjectionControls,
+        projection_controls: ProjectionControls = ProjectionControls(),
     ):
         self.template_v2_start_year = None
         self.projection_controls = projection_controls
@@ -1665,7 +1665,7 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
         """
         if emissions_t.empty:
             return None
-        emissions_scopes = dict.fromkeys(EScope.get_scopes(), [])
+        emissions_scopes: Dict[str, List[IEmissionRealization]] = dict.fromkeys(EScope.get_scopes(), [])
         for scope_name, emissions in emissions_t.items():
             if not emissions.empty:
                 emissions_scopes[scope_name] = [
@@ -1699,7 +1699,7 @@ class TemplateProviderCompany(BaseCompanyDataProvider):
         """
         if intensities_t.empty:
             return None
-        intensity_scopes = dict.fromkeys(EScope.get_scopes(), [])
+        intensity_scopes: Dict[str, List[IEIRealization]] = dict.fromkeys(EScope.get_scopes(), [])
         for scope_name, intensities in intensities_t.items():
             if not intensities.empty:
                 intensity_scopes[scope_name] = [

--- a/src/ITR/data/vault_providers.py
+++ b/src/ITR/data/vault_providers.py
@@ -621,14 +621,7 @@ class VaultProviderIntensityBenchmark(IntensityBenchmarkDataProvider):
         :param scope: a scope
         :return: pd.Series
         """
-        result = []
-        breakpoint()
-        for bm in self._EI_benchmarks.dict()[str(scope)]["benchmarks"]:  # type: ignore
-            result.append(self._convert_benchmark_to_series(IBenchmark.model_validate(bm)))
-        df_bm = pd.DataFrame(result)
-        df_bm.index.names = [self.column_config.REGION, self.column_config.SECTOR]
-
-        return df_bm
+        raise NotImplementedError
 
     def _get_intensity_benchmarks(
         self, company_sector_region_info: Optional[pd.DataFrame] = None, scope_to_calc: Optional[EScope] = None

--- a/src/ITR/interfaces.py
+++ b/src/ITR/interfaces.py
@@ -217,9 +217,9 @@ class PortfolioCompany(BaseModel):
 
     company_name: str
     company_id: str
-    company_isin: Optional[str] = None
+    company_isin: Optional[str] = ""
     investment_value: MonetaryQuantity
-    user_fields: Optional[dict] = None
+    user_fields: Optional[Dict[str, str]] = {}
 
 
 # U is Unquantified, which is presently how our benchmarks come in (production_metric comes in elsewhere)
@@ -241,15 +241,15 @@ class IBenchmark(BaseModel):
     sector: str
     region: str
     benchmark_metric: BenchmarkMetric
-    projections_nounits: Optional[List[UProjection]] = None
-    projections: Optional[List[IProjection]] = None
+    projections_nounits: List[UProjection]
+    projections: List[IProjection]
     base_year_production: Optional[ProductionQuantity] = None  # FIXME: applies only to production benchmarks
 
     def __init__(
         self,
         benchmark_metric,
-        projections_nounits=None,
-        projections=None,
+        projections_nounits=[],
+        projections=[],
         base_year_production=None,
         *args,
         **kwargs,
@@ -295,18 +295,14 @@ class IBenchmarks(BaseModel):
     def __getitem__(self, item):
         return getattr(self, item)
 
+empty_IBenchmarks = IBenchmarks(benchmarks=[], production_centric=False)
 
 # These IProductionBenchmarkScopes and IEIBenchmarkScopes are vessels for holding initialization data
 # The CompanyDataProvider methods create their own dataframes that are then used throughout
 
 
 class IProductionBenchmarkScopes(BaseModel):
-    AnyScope: Optional[IBenchmarks] = None
-    S1: Optional[IBenchmarks] = None
-    S2: Optional[IBenchmarks] = None
-    S1S2: Optional[IBenchmarks] = None
-    S3: Optional[IBenchmarks] = None
-    S1S2S3: Optional[IBenchmarks] = None
+    AnyScope: IBenchmarks
 
     def __getitem__(self, item):
         return getattr(self, item)
@@ -315,11 +311,11 @@ class IProductionBenchmarkScopes(BaseModel):
 class IEIBenchmarkScopes(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    S1: Optional[IBenchmarks] = None
-    S2: Optional[IBenchmarks] = None
-    S1S2: Optional[IBenchmarks] = None
-    S3: Optional[IBenchmarks] = None
-    S1S2S3: Optional[IBenchmarks] = None
+    S1: Optional[IBenchmarks] = empty_IBenchmarks
+    S2: Optional[IBenchmarks] = empty_IBenchmarks
+    S1S2: Optional[IBenchmarks] = empty_IBenchmarks
+    S3: Optional[IBenchmarks] = empty_IBenchmarks
+    S1S2S3: Optional[IBenchmarks] = empty_IBenchmarks
     benchmark_temperature: delta_degC_Quantity
     benchmark_global_budget: EmissionsQuantity
     is_AFOLU_included: bool
@@ -332,7 +328,7 @@ class ICompanyEIProjection(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     year: int
-    value: Optional[EI_Quantity] = None
+    value: EI_Quantity
 
     def __getitem__(self, item):
         return getattr(self, item)
@@ -382,7 +378,7 @@ class ICompanyEIProjections(BaseModel):
 class DF_ICompanyEIProjections(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    ei_metric: Optional[EI_Metric] = None
+    ei_metric: EI_Metric
     projections: pd.Series
 
     @field_validator("projections")

--- a/src/ITR/interfaces.py
+++ b/src/ITR/interfaces.py
@@ -172,6 +172,8 @@ class Aggregation(BaseModel):
     def __getitem__(self, item):
         return getattr(self, item)
 
+    def empty(self):
+        return len(self.contributions) == 0
 
 emptyAggregation = Aggregation()
 
@@ -186,6 +188,8 @@ class ScoreAggregation(BaseModel):
     def __getitem__(self, item):
         return getattr(self, item)
 
+    def empty(self):
+        return self.all.empty()
 
 emptyScoreAggregation = ScoreAggregation()
 
@@ -530,7 +534,7 @@ class ICompanyEIProjectionsScopes(BaseModel):
                     )
 
     def empty(self):
-        return self is empty_ICompanyEIProjectionsScopes
+        return self == empty_ICompanyEIProjectionsScopes
 
 
 empty_ICompanyEIProjectionsScopes = ICompanyEIProjectionsScopes()
@@ -593,7 +597,7 @@ class IHistoricEmissionsScopes(BaseModel):
         return str(pd.DataFrame.from_dict(dict_items))
 
     def empty(self):
-        return self is empty_IHistoricEmissionsScopes
+        return self == empty_IHistoricEmissionsScopes
 
 
 empty_IHistoricEmissionsScopes = IHistoricEmissionsScopes()
@@ -650,7 +654,7 @@ class IHistoricEIScopes(BaseModel):
         return str(pd.DataFrame.from_dict(dict_items))
 
     def empty(self):
-        return self is empty_IHistoricEIScopes
+        return self == empty_IHistoricEIScopes
 
 
 empty_IHistoricEIScopes = IHistoricEIScopes()

--- a/src/ITR/interfaces.py
+++ b/src/ITR/interfaces.py
@@ -175,6 +175,7 @@ class Aggregation(BaseModel):
     def empty(self):
         return len(self.contributions) == 0
 
+
 emptyAggregation = Aggregation()
 
 
@@ -190,6 +191,7 @@ class ScoreAggregation(BaseModel):
 
     def empty(self):
         return self.all.empty()
+
 
 emptyScoreAggregation = ScoreAggregation()
 

--- a/src/ITR/utils.py
+++ b/src/ITR/utils.py
@@ -17,7 +17,7 @@ from .configs import (
     TemperatureScoreControls,
 )
 from .data.data_warehouse import DataWarehouse
-from .data.osc_units import Q_, Quantity_type, asPintSeries
+from .data.osc_units import Q_, asPintSeries, delta_degC_Quantity
 from .interfaces import EScope, ETimeFrames, PortfolioCompany, ScoreAggregations
 from .portfolio_aggregation import PortfolioAggregationMethod
 from .temperature_score import TemperatureScore
@@ -95,8 +95,9 @@ def get_data(data_warehouse: DataWarehouse, portfolio: List[PortfolioCompany]) -
     :param portfolio: A list of PortfolioCompany models
     :return: A data frame containing the relevant company data indexed by (COMPANY_ID, SCOPE)
     """
+    company_ids = set(data_warehouse.company_data.get_company_ids())
     df_portfolio = pd.DataFrame.from_records(
-        [_flatten_user_fields(c) for c in portfolio if c.company_id not in data_warehouse.company_data.missing_ids]
+        [_flatten_user_fields(c) for c in portfolio if c.company_id in company_ids]
     )
     df_portfolio[ColumnsConfig.INVESTMENT_VALUE] = asPintSeries(df_portfolio[ColumnsConfig.INVESTMENT_VALUE])
 
@@ -152,7 +153,7 @@ def get_data(data_warehouse: DataWarehouse, portfolio: List[PortfolioCompany]) -
 
 def calculate(
     portfolio_data: pd.DataFrame,
-    fallback_score: Quantity_type("delta_degC"),
+    fallback_score: delta_degC_Quantity,
     aggregation_method: PortfolioAggregationMethod,
     grouping: Optional[List[str]],
     time_frames: List[ETimeFrames],

--- a/test/inputs/json/test_project_reference.json
+++ b/test/inputs/json/test_project_reference.json
@@ -317,7 +317,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -921,7 +927,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -1334,8 +1346,14 @@
     "target_probability": 0.4285714285714285,
     "target_data": null,
     "historic_data": {
-      "productions": null,
-      "emissions": null,
+      "productions": [],
+      "emissions": {
+        "S1": [],
+        "S2": [],
+        "S1S2": [],
+        "S3": [],
+        "S1S2S3": []
+      },
       "emissions_intensities": {
         "S1": [
           {
@@ -1466,7 +1484,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -2176,7 +2200,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -2886,7 +2916,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -3596,7 +3632,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -4306,7 +4348,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -5016,7 +5064,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -5726,7 +5780,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -6436,7 +6496,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -7146,7 +7212,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -7856,7 +7928,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -8566,7 +8644,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -9276,7 +9360,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -9986,7 +10076,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/GJ",
@@ -10566,7 +10662,13 @@
         "S3": [],
         "S1S2S3": []
       },
-      "emissions_intensities": null
+      "emissions_intensities": {
+        "S1": [],
+        "S2": [],
+        "S1S2": [],
+        "S3": [],
+        "S1S2S3": []
+      }
     },
     "country": null,
     "emissions_metric": "t CO2",
@@ -10584,7 +10686,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": null,
       "S2": null,
@@ -10898,7 +11006,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -11608,7 +11722,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -12318,7 +12438,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -13028,7 +13154,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -13738,7 +13870,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -14448,7 +14586,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -15158,7 +15302,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -15868,7 +16018,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -16578,7 +16734,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -17288,7 +17450,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -17998,7 +18166,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -18708,7 +18882,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -19418,7 +19598,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",
@@ -20128,7 +20314,13 @@
     "company_ev_plus_cash": null,
     "company_total_assets": null,
     "company_cash_equivalents": null,
-    "projected_targets": null,
+    "projected_targets": {
+      "S1": null,
+      "S2": null,
+      "S1S2": null,
+      "S3": null,
+      "S1S2S3": null
+    },
     "projected_intensities": {
       "S1": {
         "ei_metric": "CO2\u00b7t/(t Steel)",

--- a/test/test_e2e.py
+++ b/test/test_e2e.py
@@ -18,17 +18,21 @@ from ITR.temperature_score import TemperatureScore
 
 class e2e_DataProvider:  # if derived from CompanyDataProvider, we'd have to provide implementations for several methods we never use
     def __init__(self, companies: List[ICompanyAggregates]):
-        self.companies = companies
-        self.missing_ids = set([])
+        self._companies = companies
+
+    def get_company_ids(self) -> List[str]:
+        company_ids = [c.company_id for c in self._companies]
+        return company_ids
 
 
 class e2e_DataWarehouse(DataWarehouse):
     def __init__(self, company_data: e2e_DataProvider):
         # super().__init__(company_data, ProductionBenchmarkDataProvider(), IntensityBenchmarkDataProvider())
-        self.company_data = company_data
+        self.company_data = company_data  # type: ignore
 
     def get_preprocessed_company_data(self, company_ids: List[str]) -> List[ICompanyAggregates]:
-        return self.company_data.companies
+        assert isinstance(self.company_data, e2e_DataProvider)
+        return self.company_data._companies
 
 
 class EndToEndTest(unittest.TestCase):
@@ -176,7 +180,7 @@ class EndToEndTest(unittest.TestCase):
 
     # Run some regression tests
     # @unittest.skip("only run for longer test runs")
-    def test_regression_companies(self):
+    def test_regression_companies(self) -> None:
         nr_companies = 1000
 
         # test 10000 companies
@@ -215,7 +219,7 @@ class EndToEndTest(unittest.TestCase):
 
         self.assertAlmostEqual(agg_scores.long.S1S2.all.score, self.BASE_COMP_SCORE, places=2)
 
-    def test_grouping(self):
+    def test_grouping(self) -> None:
         """
         Testing the grouping feature with two different industry levels and making sure the results are present
         """

--- a/test/test_projection.py
+++ b/test/test_projection.py
@@ -294,4 +294,5 @@ if __name__ == "__main__":
     s.interpolate(method="linear")
     test = TestProjector()
     test.setUp()
-    test.test_project()
+    test.test_trajectories()
+    test.test_targets()

--- a/test/test_projection.py
+++ b/test/test_projection.py
@@ -41,6 +41,8 @@ def is_pint_dict_equal(result: List[dict], reference: List[dict]) -> bool:
                     if not result[i][k]:
                         continue
                     for scope in result[i][k]:
+                        if reference[i][k] is None:
+                            breakpoint()
                         if reference[i][k].get(scope):
                             vref = reference[i][k]
                             if not v.get(scope):
@@ -239,7 +241,7 @@ class TestProjector(unittest.TestCase):
                     )
                 assert_pint_series_equal(self, test_projection, expected[i], places=3)
             else:
-                assert c.projected_targets is None
+                assert c.projected_targets.empty()
 
     def test_extrapolate(self):
         with open(os.path.join(self.root, "inputs", "json", "test_fillna_companies.json"), "r") as file:

--- a/test/test_targets.py
+++ b/test/test_targets.py
@@ -1583,7 +1583,7 @@ class TestTargets(unittest.TestCase):
 
         self.base_company_data = BaseCompanyDataProvider(company_data)
         # Since we are not using a Data Warehouse to compute our graphics, we have to do this projection manually, with the benchmark's internal dataframe.
-        self.base_company_data._validate_projected_trajectories(self.base_company_data._companies, ei_df_t)
+        self.base_company_data._validate_projected_trajectories(self.base_company_data._companies, self.OECM_EI_S3_bm)
 
         co_pp = bm_production_data.droplevel("scope")
 

--- a/test/test_targets.py
+++ b/test/test_targets.py
@@ -103,7 +103,7 @@ class TestTargets(unittest.TestCase):
         # By default, gen_company_data sets targets, but we want to set intensities...
         company_data.projected_intensities = company_data.projected_targets
         # And we will test how targets expressed in target_data get interpreted/extrapolated
-        company_data.projected_targets = None
+        company_data.projected_targets = ITR.interfaces.empty_ICompanyEIProjectionsScopes
         return company_data
 
     def test_target_netzero(self):


### PR DESCRIPTION
It turns out that several of the enhancements added to the Base DataProvider classes and also used by the DataWarehouse revealed many violations of proper data abstraction.  These changes refactor data structures and methods related to Company data, Production benchmarks, and Emissions Intensity benchmarks while also passing mypy scrutiny.

Moreover, from mypy's perspective, it's an anti-pattern to use None as an empty value.  Rather, there should be strongly typed empty values (which were don't for Aggregation and friends, but need to be done more generally throughout).

Because these changes were made all at once and relatively rapidly, it's quite likely we will want to continue evolving them until we are happy with names, interfaces, and overall behavior.

Vault Providers in particular is going to need work to get back up to scratch.

Starting with this as a Draft pull request because I haven't yet tested against ITR-examples, but want to give all y'all a preview as I do...