### PR TITLE
Add `py.typed` file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ dependencies = [
     "globalwarmingpotentials>=0.9.4",
 ]
 
+[tool.setuptools.package-data]
+itr = [
+      "py.typed"
+      ]
+
 [project.urls]
 Homepage = "https://github.com/os-climate/ITR"
 Repository = "https://github.com/os-climate/ITR"

--- a/src/ITR/temperature_score.py
+++ b/src/ITR/temperature_score.py
@@ -43,7 +43,7 @@ class TemperatureScore(PortfolioAggregation):
     def __init__(
         self,
         time_frames: List[ETimeFrames],
-        scopes: List[EScope],
+        scopes: Optional[List[EScope]] = None,
         fallback_score: float = Q_(3.2, ureg.delta_degC),
         aggregation_method: PortfolioAggregationMethod = PortfolioAggregationMethod.WATS,
         budget_column: str = ColumnsConfig.CUMULATIVE_BUDGET,


### PR DESCRIPTION
Add a `py.typed` file so that ITR library users can actually use the type hints from the library.  Also fix up an error found by actually using the type hints in ITR-examples.