### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           ### SHELL CODE START ###
 
-          set -xeu -o pipefail
+          set -eu -o pipefail
 
           # Define variables
 


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit