### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -36,6 +36,7 @@ jobs:
           ### SHELL CODE START ###
 
           set -eu -o pipefail
+          set -x
 
           # Define variables
 
@@ -139,6 +140,8 @@ jobs:
           }
 
           # Main script entry point
+
+          echo "HEAD branch detected as: $HEAD_BRANCH"
 
           # Ensure working from top-level of GIT repository
           CURRENT_DIR=$(pwd)


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit