### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -203,7 +203,7 @@ jobs:
           fi
 
 
-          if (logged_in_github) && ! (check_prs); then
+          if ! (check_prs); then
             # No existing open pull requests found for this repository
 
             # Remove remote branch if it exists
@@ -295,7 +295,6 @@ jobs:
             echo "branchname=$AUTOMATION_BRANCH" >> "$GITHUB_OUTPUT"
             echo "headbranch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
             # Move to the next workflow step to raise the PR
-            git push --set-upstream origin "$AUTOMATION_BRANCH"
             exit 0
           fi
 
@@ -323,8 +322,8 @@ jobs:
       - name: Create Pull Request
         if: steps.update-repository.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
-        # env:
-        #   GITHUB_TOKEN: ${{ github.token }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           # Note: Requires a specific/defined Personal Access Token
           token: ${{ secrets.ACTIONS_WORKFLOW }}

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -47,10 +47,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: "Install dependencies"
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
+      - name: "Setup PDM for build commands"
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: "Tag for test release"
         # Delete all local tags, then create a synthetic tag for testing
@@ -62,6 +62,18 @@ jobs:
           git checkout "tags/v${{ steps.setenv.outputs.vernum }}"
           grep version pyproject.toml
 
-      - name: "Build with TOX"
+      - name: "Performing build"
         run: |
-          tox -e build
+          PDM_CMD=$(which pdm)
+          if [ -f tox.ini ]; then
+            python -m pip install --upgrade pip
+            pip install tox tox-gh-actions
+            echo "Building with command: tox -e build"
+            tox -e build
+          elif [ -x "$PDM_CMD" ]; then
+            echo "Building with command: pdm build"
+            pdm build
+          else
+            echo "Building with command: python -m build"
+            python -m build
+          fi

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,10 @@
+---
+# Markdownlint configuration file
+
+# Default state for all rules
+default: true
+
+# Path to configuration file to extend
+extends: null
+
+MD013: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
   #       args: ['--py37-plus']
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.4.0
     hooks:
       - id: black
       - id: black-jupyter


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit