### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -64,16 +64,25 @@ jobs:
 
       - name: "Performing build"
         run: |
-          PDM_CMD=$(which pdm)
+          python -m pip install --upgrade pip
           if [ -f tox.ini ]; then
-            python -m pip install --upgrade pip
             pip install tox tox-gh-actions
+            echo "Found file: tox.ini"
             echo "Building with command: tox -e build"
             tox -e build
-          elif [ -x "$PDM_CMD" ]; then
+          elif [ -f pyproject.toml ]; then
+            echo "Found file: pyproject.toml"
             echo "Building with command: pdm build"
             pdm build
           else
-            echo "Building with command: python -m build"
+            echo "Neither file found: tox.ini/pyproject.toml"
+            pip install --upgrade build
+            echo "Attempting build with: python -m build"
             python -m build
           fi
+
+      - name: "Validating Artefacts with Twine"
+        run: |
+          echo "Validating artefacts with: twine check dist/*"
+          pip install --upgrade twine
+          twine check dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,10 @@ on:
   # workflow_dispatch:
   push:
     # Only invoked on release tag pushes
+    branches:
+      - '**'
     tags:
-      - v*.*.*
+      - 'v*.*.*'
 
 env:
   python-version: "3.10"
@@ -18,8 +20,11 @@ env:
 ### BUILD ###
 
 jobs:
+
   build:
     name: "🐍 Build packages"
+    # Only publish on tag pushes
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: mandatory for Sigstore
@@ -90,6 +95,21 @@ jobs:
           prerelease: false
           automatic_release_tag: ${{ github.ref_name }}
           title: ${{ github.ref_name }}
+          files: |
+            dist/*.tar.gz
+            dist/*.whl
+            dist/*.sigstore
+
+      - name: "📦 Publish artefacts to GitHub"
+        # https://github.com/softprops/action-gh-release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          tag_name: ${{ github.ref_name }}
+          name: "Test/Development Build \
+            ${{ github.ref_name }}"
+          # body_path: ${{ github.workspace }}/CHANGELOG.rst
           files: |
             dist/*.tar.gz
             dist/*.whl

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -103,16 +103,16 @@ jobs:
           echo "tarball=$(ls dist/*.tgz)" >> "$GITHUB_OUTPUT"
           echo "wheel=$(ls dist/*.whl)" >> "$GITHUB_OUTPUT"
 
-      - name: "📦 Publish packages to GitHub"
-        uses: ModeSevenIndustrialSolutions/action-automatic-releases@latest
+      - name: "📦 Publish artefacts to GitHub"
+        # https://github.com/softprops/action-gh-release
+        uses: softprops/action-gh-release@v2
         with:
-          # Valid inputs are:
-          # repo_token, automatic_release_tag, draft, prerelease, title, files
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          automatic_release_tag: ${{ steps.setenv.outputs.vernum }}
-          title: "Development Build \
+          tag_name: ${{ steps.setenv.outputs.vernum }}
+          name: "Test/Development Build \
             ${{ steps.setenv.outputs.vernum }}"
+          # body_path: ${{ github.workspace }}/CHANGELOG.rst
           files: |
             dist/*.tar.gz
             dist/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 # Temporary devops repo
 .devops
 
+# Twine temporary files
+package-lock.json
+package.json
+
 # Output files from co2budget.ipynb (ITR-Examples)
 OECM-images
 TPI-images
-
 
 # Local node cache
 node_modules


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit