### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,0 +1,152 @@
+---
+name: "🐍📦 Test build and release"
+
+# GitHub/PyPI trusted publisher documentation:
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+
+env:
+  python-version: "3.10"
+
+### BUILD ###
+
+jobs:
+  build:
+    name: "🐍 Build packages"
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: mandatory for Sigstore
+      id-token: write
+    steps:
+      ### BUILDING ###
+
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "Setup Python 3.10"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.python-version }}
+
+      - name: "Setup PDM for build commands"
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: ${{ env.python-version }}
+
+      - name: "Populate environment variables"
+        id: setenv
+        run: |
+          vernum="${{ env.python-version }}.$(date +'%Y%m%d%H%M')"
+          echo "vernum=${vernum}" >> "$GITHUB_OUTPUT"
+          echo "vernum=${vernum}" >> buildvars.txt
+
+      - name: "Tag for test release"
+        # Delete all local tags, then create a synthetic tag for testing
+        # Use the date/time to avoid conflicts uploading to Test PyPI
+        run: |
+          scripts/dev-versioning.sh "${{ steps.setenv.outputs.vernum }}"
+          git tag | xargs -L 1 | xargs git tag --delete
+          git tag "v${{ steps.setenv.outputs.vernum }}"
+          git checkout "tags/v${{ steps.setenv.outputs.vernum }}"
+          grep version pyproject.toml
+
+      - name: "Build with PDM backend"
+        run: |
+          pdm build
+          # Need to save the build environment for subsequent steps
+          mv buildvars.txt dist/buildvars.txt
+
+      ### SIGNING ###
+
+      - name: "Sign packages with Sigstore"
+        uses: sigstore/gh-action-sigstore-python@v2
+
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: Development
+          path: dist/
+
+  ### PUBLISH GITHUB ###
+
+  github:
+    name: "📦 Test publish to GitHub"
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: mandatory to publish artefacts
+      contents: write
+    steps:
+      - name: "⬇ Download build artefacts"
+        uses: actions/download-artifact@v4
+        with:
+          name: Development
+          path: dist/
+
+      - name: "Source environment variables"
+        id: setenv
+        run: |
+          if [ -f dist/buildvars.txt ]; then
+            source dist/buildvars.txt
+            echo "vernum=${vernum}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Build environment variables could not be sourced"
+          fi
+          echo "tarball=$(ls dist/*.tgz)" >> "$GITHUB_OUTPUT"
+          echo "wheel=$(ls dist/*.whl)" >> "$GITHUB_OUTPUT"
+
+      - name: "📦 Publish artefacts to GitHub"
+        # https://github.com/softprops/action-gh-release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          tag_name: ${{ steps.setenv.outputs.vernum }}
+          name: "Test/Development Build \
+            ${{ steps.setenv.outputs.vernum }}"
+          # body_path: ${{ github.workspace }}/CHANGELOG.rst
+          files: |
+            dist/*.tar.gz
+            dist/*.whl
+            dist/*.sigstore
+
+  ### PUBLISH TEST PYPI ###
+
+  testpypi:
+    name: "📦 Test publish to PyPi"
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+    permissions:
+      # IMPORTANT: mandatory for trusted publishing
+      id-token: write
+    steps:
+      - name: "⬇ Download build artefacts"
+        uses: actions/download-artifact@v4
+        with:
+          name: Development
+          path: dist/
+
+      - name: "Remove files unsupported by PyPi"
+        run: |
+          if [ -f dist/buildvars.txt ]; then
+            rm dist/buildvars.txt
+          fi
+          rm dist/*.sigstore
+
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          repository-url: https://test.pypi.org/legacy/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,9 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
-        args: [ "-d", "{rules: {line-length: {max: 120}}, ignore-from-file: [.gitignore],}", ]
+        args:
+          ["-d", "{rules: {line-length: {max: 120}},
+          ignore-from-file: [.gitignore],}"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.2
@@ -88,7 +90,8 @@ repos:
         name: "create mypy cache"
         language: system
         pass_filenames: false
-        entry: bash -c 'if [ ! -d .mypy_cache ]; then /bin/mkdir .mypy_cache; fi; exit 0'
+        entry: bash -c 'if [ ! -d .mypy_cache ];
+          then /bin/mkdir .mypy_cache; fi; exit 0'
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.10.1"
@@ -98,11 +101,12 @@ repos:
         args: ["--show-error-codes", "--install-types", "--non-interactive"]
         additional_dependencies: ["pytest", "types-requests"]
 
+# yamllint disable rule:comments-indentation
   # Check for misspellings in documentation files
   # - repo: https://github.com/codespell-project/codespell
   #   rev: v2.2.2
   #   hooks:
-  #   - id: codespell
+  #     - id: codespell
 
   # Automatically upgrade Python syntax for newer versions
   # - repo: https://github.com/asottile/pyupgrade
@@ -110,3 +114,4 @@ repos:
   #   hooks:
   #     - id: pyupgrade
   #       args: ['--py37-plus']
+# yamllint enable rule:comments-indentation


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit